### PR TITLE
feat: persist comic layout state

### DIFF
--- a/app/Models/ComicModel.php
+++ b/app/Models/ComicModel.php
@@ -9,7 +9,8 @@ class ComicModel
     private string $stateFile;
     private array $state = [
         'images' => [],
-        'pages' => []
+        'pages' => [],
+        'pageCount' => 0
     ];
 
     public function __construct()
@@ -112,6 +113,7 @@ class ComicModel
     public function setPages(array $pages): void
     {
         $this->state['pages'] = $pages;
+        $this->state['pageCount'] = count($pages);
         $this->saveState();
     }
 

--- a/app/Views/index.php
+++ b/app/Views/index.php
@@ -30,6 +30,7 @@
 <script>
 const layouts = <?= json_encode(array_keys($layouts)) ?>;
 const layoutTemplates = <?= json_encode($templates) ?>;
+const savedPages = <?= json_encode($pages) ?>;
 </script>
 <script src="/js/app.js"></script>
 </body>


### PR DESCRIPTION
## Summary
- track page count in state.json and persist on save
- restore saved pages and layouts on load
- return images to sidebar when page layout changes

## Testing
- `composer install`
- `php -l app/Models/ComicModel.php app/Views/index.php app/Controllers/ComicController.php`
- `node --check public/js/app.js`


------
https://chatgpt.com/codex/tasks/task_e_68914d0626f4832a860e28d7e495b227