### PR TITLE
Improve layout grid and image controls

### DIFF
--- a/layouts/1panel.php
+++ b/layouts/1panel.php
@@ -1,3 +1,3 @@
 <div class="layout one-panel">
-    <div class="panel" data-slot="1">{{slot1}}</div>
+    <div class="panel" data-slot="1"></div>
 </div>

--- a/layouts/2panel-h.php
+++ b/layouts/2panel-h.php
@@ -1,4 +1,4 @@
 <div class="layout two-panel-h">
-    <div class="panel" data-slot="1">{{slot1}}</div>
-    <div class="panel" data-slot="2">{{slot2}}</div>
+    <div class="panel" data-slot="1"></div>
+    <div class="panel" data-slot="2"></div>
 </div>

--- a/layouts/2panel-v.php
+++ b/layouts/2panel-v.php
@@ -1,4 +1,4 @@
 <div class="layout two-panel-v">
-    <div class="panel" data-slot="1">{{slot1}}</div>
-    <div class="panel" data-slot="2">{{slot2}}</div>
+    <div class="panel" data-slot="1"></div>
+    <div class="panel" data-slot="2"></div>
 </div>

--- a/layouts/3panel-h.php
+++ b/layouts/3panel-h.php
@@ -1,5 +1,5 @@
 <div class="layout three-panel-h">
-    <div class="panel" data-slot="1">{{slot1}}</div>
-    <div class="panel" data-slot="2">{{slot2}}</div>
-    <div class="panel" data-slot="3">{{slot3}}</div>
+    <div class="panel" data-slot="1"></div>
+    <div class="panel" data-slot="2"></div>
+    <div class="panel" data-slot="3"></div>
 </div>

--- a/layouts/3panel-v.php
+++ b/layouts/3panel-v.php
@@ -1,5 +1,5 @@
 <div class="layout three-panel-v">
-    <div class="panel" data-slot="1">{{slot1}}</div>
-    <div class="panel" data-slot="2">{{slot2}}</div>
-    <div class="panel" data-slot="3">{{slot3}}</div>
+    <div class="panel" data-slot="1"></div>
+    <div class="panel" data-slot="2"></div>
+    <div class="panel" data-slot="3"></div>
 </div>

--- a/layouts/4panel-grid.php
+++ b/layouts/4panel-grid.php
@@ -1,6 +1,6 @@
 <div class="layout four-panel-grid">
-    <div class="panel" data-slot="1">{{slot1}}</div>
-    <div class="panel" data-slot="2">{{slot2}}</div>
-    <div class="panel" data-slot="3">{{slot3}}</div>
-    <div class="panel" data-slot="4">{{slot4}}</div>
+    <div class="panel" data-slot="1"></div>
+    <div class="panel" data-slot="2"></div>
+    <div class="panel" data-slot="3"></div>
+    <div class="panel" data-slot="4"></div>
 </div>

--- a/layouts/4panel-stack.php
+++ b/layouts/4panel-stack.php
@@ -1,6 +1,6 @@
 <div class="layout four-panel-stack">
-    <div class="panel" data-slot="1">{{slot1}}</div>
-    <div class="panel" data-slot="2">{{slot2}}</div>
-    <div class="panel" data-slot="3">{{slot3}}</div>
-    <div class="panel" data-slot="4">{{slot4}}</div>
+    <div class="panel" data-slot="1"></div>
+    <div class="panel" data-slot="2"></div>
+    <div class="panel" data-slot="3"></div>
+    <div class="panel" data-slot="4"></div>
 </div>

--- a/layouts/5panel-mix.php
+++ b/layouts/5panel-mix.php
@@ -1,7 +1,7 @@
 <div class="layout five-panel-mix">
-    <div class="panel" data-slot="1">{{slot1}}</div>
-    <div class="panel" data-slot="2">{{slot2}}</div>
-    <div class="panel" data-slot="3">{{slot3}}</div>
-    <div class="panel" data-slot="4">{{slot4}}</div>
-    <div class="panel" data-slot="5">{{slot5}}</div>
+    <div class="panel" data-slot="1"></div>
+    <div class="panel" data-slot="2"></div>
+    <div class="panel" data-slot="3"></div>
+    <div class="panel" data-slot="4"></div>
+    <div class="panel" data-slot="5"></div>
 </div>

--- a/layouts/6panel-grid.php
+++ b/layouts/6panel-grid.php
@@ -1,8 +1,8 @@
 <div class="layout six-panel-grid">
-    <div class="panel" data-slot="1">{{slot1}}</div>
-    <div class="panel" data-slot="2">{{slot2}}</div>
-    <div class="panel" data-slot="3">{{slot3}}</div>
-    <div class="panel" data-slot="4">{{slot4}}</div>
-    <div class="panel" data-slot="5">{{slot5}}</div>
-    <div class="panel" data-slot="6">{{slot6}}</div>
+    <div class="panel" data-slot="1"></div>
+    <div class="panel" data-slot="2"></div>
+    <div class="panel" data-slot="3"></div>
+    <div class="panel" data-slot="4"></div>
+    <div class="panel" data-slot="5"></div>
+    <div class="panel" data-slot="6"></div>
 </div>

--- a/layouts/titlefull.php
+++ b/layouts/titlefull.php
@@ -1,3 +1,3 @@
 <div class="layout title-full">
-    <div class="panel" data-slot="1">{{slot1}}</div>
+    <div class="panel" data-slot="1"></div>
 </div>

--- a/public/css/style.css
+++ b/public/css/style.css
@@ -1,9 +1,72 @@
-body{font-family:Arial,sans-serif;margin:0;padding:0;}
-#container{display:flex;width:100vw;height:100vh;}
-#images{width:30%;padding:10px;border-right:1px solid #ccc;overflow-y:auto;}
-#builder{flex:1;padding:10px;overflow-y:auto;}
-.thumb{width:100px;margin:5px;cursor:grab;}
-.page{border:1px solid #ccc;padding:10px;margin-bottom:20px;}
-.layout-container{display:flex;flex-wrap:wrap;}
-.panel{border:1px dashed #999;flex:1 1 45%;min-height:100px;margin:5px;display:flex;align-items:center;justify-content:center;}
-.panel img{max-width:100%;max-height:100%;}
+body {
+    font-family: Arial, sans-serif;
+    margin: 0;
+    padding: 0;
+}
+
+#container {
+    display: flex;
+    width: 100vw;
+    height: 100vh;
+}
+
+#images {
+    width: 30%;
+    padding: 10px;
+    border-right: 1px solid #ccc;
+    overflow-y: auto;
+}
+
+#builder {
+    flex: 1;
+    padding: 10px;
+    overflow-y: auto;
+}
+
+#pages {
+    display: grid;
+    grid-template-columns: repeat(2, 1fr);
+    gap: 20px;
+}
+
+.thumb {
+    width: 100px;
+    margin: 5px;
+    cursor: grab;
+}
+
+.page {
+    border: 1px solid #ccc;
+    padding: 10px;
+}
+
+.layout-container {
+    display: flex;
+    flex-wrap: wrap;
+}
+
+.panel {
+    border: 1px dashed #999;
+    flex: 1 1 45%;
+    min-height: 100px;
+    margin: 5px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    position: relative;
+    overflow: hidden;
+}
+
+.panel:empty::before {
+    content: 'Drop image';
+    color: #999;
+    font-size: 14px;
+}
+
+.panel img {
+    max-width: 100%;
+    max-height: 100%;
+    cursor: move;
+    user-select: none;
+    transition: transform 0.1s ease-out;
+}

--- a/public/js/app.js
+++ b/public/js/app.js
@@ -21,6 +21,43 @@ document.addEventListener('DOMContentLoaded', () => {
     const imageList = document.getElementById('imageList');
     let pageCounter = 0;
 
+    function enableImageControls(img) {
+        let scale = 1;
+        let translateX = 0;
+        let translateY = 0;
+
+        function updateTransform() {
+            img.style.transform = `translate(${translateX}px, ${translateY}px) scale(${scale})`;
+        }
+
+        img.addEventListener('wheel', e => {
+            e.preventDefault();
+            const delta = e.deltaY < 0 ? 0.1 : -0.1;
+            scale = Math.min(3, Math.max(0.5, scale + delta));
+            updateTransform();
+        });
+
+        let dragging = false;
+        let startX, startY;
+        img.addEventListener('mousedown', e => {
+            e.preventDefault();
+            dragging = true;
+            startX = e.clientX - translateX;
+            startY = e.clientY - translateY;
+        });
+
+        document.addEventListener('mousemove', e => {
+            if (!dragging) return;
+            translateX = e.clientX - startX;
+            translateY = e.clientY - startY;
+            updateTransform();
+        });
+
+        document.addEventListener('mouseup', () => {
+            dragging = false;
+        });
+    }
+
     function returnImagesFromPage(container) {
         container.querySelectorAll('.panel img').forEach(img => {
             img.className = 'thumb';
@@ -49,6 +86,7 @@ document.addEventListener('DOMContentLoaded', () => {
                 panel.innerHTML = '';
                 const clone = img.cloneNode();
                 clone.draggable = false;
+                enableImageControls(clone);
                 panel.appendChild(clone);
                 img.remove();
                 const hidden = document.createElement('input');
@@ -64,6 +102,7 @@ document.addEventListener('DOMContentLoaded', () => {
                     panel.innerHTML = '';
                     const clone = img.cloneNode();
                     clone.draggable = false;
+                    enableImageControls(clone);
                     panel.appendChild(clone);
                     img.remove();
                     const hidden = document.createElement('input');


### PR DESCRIPTION
## Summary
- Display builder pages in two-column grid with drop-zone previews
- Allow dropped images to be zoomed and panned inside panels
- Remove placeholder text from layout templates

## Testing
- `node --check public/js/app.js`
- `for f in layouts/*.php; do php -l $f; done`

------
https://chatgpt.com/codex/tasks/task_e_68914e7a80b4832aaaf1734ab4bc9542