### PR TITLE
Support layout-specific geometry and CSS

### DIFF
--- a/app/Controllers/ComicController.php
+++ b/app/Controllers/ComicController.php
@@ -18,6 +18,7 @@ class ComicController
         $images = $this->model->getImages();
         $layouts = $this->model->getLayouts();
         $templates = $this->model->getLayoutTemplates();
+        $styles = $this->model->getLayoutStyles();
         $pages = $this->model->getPages();
         include __DIR__ . '/../Views/index.php';
     }

--- a/app/Views/index.php
+++ b/app/Views/index.php
@@ -30,6 +30,7 @@
 <script>
 const layouts = <?= json_encode(array_keys($layouts)) ?>;
 const layoutTemplates = <?= json_encode($templates) ?>;
+const layoutStyles = <?= json_encode($styles) ?>;
 const savedPages = <?= json_encode($pages) ?>;
 </script>
 <script src="/js/app.js"></script>

--- a/layouts/1panel.php
+++ b/layouts/1panel.php
@@ -1,3 +1,0 @@
-<div class="layout one-panel">
-    <div class="panel" data-slot="1"></div>
-</div>

--- a/layouts/2panel-h.php
+++ b/layouts/2panel-h.php
@@ -1,4 +1,0 @@
-<div class="layout two-panel-h">
-    <div class="panel" data-slot="1"></div>
-    <div class="panel" data-slot="2"></div>
-</div>

--- a/layouts/2panel-v.php
+++ b/layouts/2panel-v.php
@@ -1,4 +1,0 @@
-<div class="layout two-panel-v">
-    <div class="panel" data-slot="1"></div>
-    <div class="panel" data-slot="2"></div>
-</div>

--- a/layouts/3panel-h.php
+++ b/layouts/3panel-h.php
@@ -1,5 +1,0 @@
-<div class="layout three-panel-h">
-    <div class="panel" data-slot="1"></div>
-    <div class="panel" data-slot="2"></div>
-    <div class="panel" data-slot="3"></div>
-</div>

--- a/layouts/3panel-v.php
+++ b/layouts/3panel-v.php
@@ -1,5 +1,0 @@
-<div class="layout three-panel-v">
-    <div class="panel" data-slot="1"></div>
-    <div class="panel" data-slot="2"></div>
-    <div class="panel" data-slot="3"></div>
-</div>

--- a/layouts/4panel-grid.php
+++ b/layouts/4panel-grid.php
@@ -1,6 +1,0 @@
-<div class="layout four-panel-grid">
-    <div class="panel" data-slot="1"></div>
-    <div class="panel" data-slot="2"></div>
-    <div class="panel" data-slot="3"></div>
-    <div class="panel" data-slot="4"></div>
-</div>

--- a/layouts/4panel-stack.php
+++ b/layouts/4panel-stack.php
@@ -1,6 +1,0 @@
-<div class="layout four-panel-stack">
-    <div class="panel" data-slot="1"></div>
-    <div class="panel" data-slot="2"></div>
-    <div class="panel" data-slot="3"></div>
-    <div class="panel" data-slot="4"></div>
-</div>

--- a/layouts/5panel-mix.php
+++ b/layouts/5panel-mix.php
@@ -1,7 +1,0 @@
-<div class="layout five-panel-mix">
-    <div class="panel" data-slot="1"></div>
-    <div class="panel" data-slot="2"></div>
-    <div class="panel" data-slot="3"></div>
-    <div class="panel" data-slot="4"></div>
-    <div class="panel" data-slot="5"></div>
-</div>

--- a/layouts/6panel-grid.php
+++ b/layouts/6panel-grid.php
@@ -1,8 +1,0 @@
-<div class="layout six-panel-grid">
-    <div class="panel" data-slot="1"></div>
-    <div class="panel" data-slot="2"></div>
-    <div class="panel" data-slot="3"></div>
-    <div class="panel" data-slot="4"></div>
-    <div class="panel" data-slot="5"></div>
-    <div class="panel" data-slot="6"></div>
-</div>

--- a/layouts/one-panel.css
+++ b/layouts/one-panel.css
@@ -1,0 +1,3 @@
+.layout.one-panel .panel1 {
+    clip-path: polygon(0 0, 100% 0, 100% 100%, 0 100%);
+}

--- a/layouts/one-panel.php
+++ b/layouts/one-panel.php
@@ -1,0 +1,3 @@
+<div class="layout one-panel">
+    <div class="panel panel1" data-slot="1"></div>
+</div>

--- a/layouts/three-panel.css
+++ b/layouts/three-panel.css
@@ -1,0 +1,9 @@
+.layout.three-panel .panel1 {
+    clip-path: polygon(0 0, 50% 0, 50% 100%, 0 100%);
+}
+.layout.three-panel .panel2 {
+    clip-path: polygon(50% 0, 100% 0, 100% 100%);
+}
+.layout.three-panel .panel3 {
+    clip-path: polygon(50% 0, 100% 100%, 50% 100%);
+}

--- a/layouts/three-panel.php
+++ b/layouts/three-panel.php
@@ -1,0 +1,5 @@
+<div class="layout three-panel">
+    <div class="panel panel1" data-slot="1"></div>
+    <div class="panel panel2" data-slot="2"></div>
+    <div class="panel panel3" data-slot="3"></div>
+</div>

--- a/layouts/titlefull.php
+++ b/layouts/titlefull.php
@@ -1,3 +1,0 @@
-<div class="layout title-full">
-    <div class="panel" data-slot="1"></div>
-</div>

--- a/layouts/two-panel-horizontal.css
+++ b/layouts/two-panel-horizontal.css
@@ -1,0 +1,6 @@
+.layout.two-panel-horizontal .panel1 {
+    clip-path: polygon(0 0, 100% 0, 100% 50%, 0 50%);
+}
+.layout.two-panel-horizontal .panel2 {
+    clip-path: polygon(0 50%, 100% 50%, 100% 100%, 0 100%);
+}

--- a/layouts/two-panel-horizontal.php
+++ b/layouts/two-panel-horizontal.php
@@ -1,0 +1,4 @@
+<div class="layout two-panel-horizontal">
+    <div class="panel panel1" data-slot="1"></div>
+    <div class="panel panel2" data-slot="2"></div>
+</div>

--- a/layouts/two-panel-vertical.css
+++ b/layouts/two-panel-vertical.css
@@ -1,0 +1,6 @@
+.layout.two-panel-vertical .panel1 {
+    clip-path: polygon(0 0, 50% 0, 50% 100%, 0 100%);
+}
+.layout.two-panel-vertical .panel2 {
+    clip-path: polygon(50% 0, 100% 0, 100% 100%, 50% 100%);
+}

--- a/layouts/two-panel-vertical.php
+++ b/layouts/two-panel-vertical.php
@@ -1,0 +1,4 @@
+<div class="layout two-panel-vertical">
+    <div class="panel panel1" data-slot="1"></div>
+    <div class="panel panel2" data-slot="2"></div>
+</div>

--- a/public/css/style.css
+++ b/public/css/style.css
@@ -41,19 +41,27 @@ body {
 }
 
 .layout-container {
-    display: flex;
-    flex-wrap: wrap;
+    position: relative;
+    width: 400px;
+    height: 400px;
+}
+
+.layout {
+    position: relative;
+    width: 100%;
+    height: 100%;
 }
 
 .panel {
     border: 1px dashed #999;
-    flex: 1 1 45%;
-    min-height: 100px;
-    margin: 5px;
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
     display: flex;
     align-items: center;
     justify-content: center;
-    position: relative;
     overflow: hidden;
 }
 

--- a/public/js/app.js
+++ b/public/js/app.js
@@ -73,8 +73,17 @@ document.addEventListener('DOMContentLoaded', () => {
         }
     });
 
+    function ensureLayoutStyle(name) {
+        if (document.getElementById('style-' + name)) return;
+        const style = document.createElement('style');
+        style.id = 'style-' + name;
+        style.textContent = layoutStyles[name] || '';
+        document.head.appendChild(style);
+    }
+
     function renderLayout(container, layoutName, pageIndex, slots = {}) {
         container.innerHTML = layoutTemplates[layoutName];
+        ensureLayoutStyle(layoutName);
         container.querySelectorAll('.panel').forEach(panel => {
             const slot = panel.getAttribute('data-slot');
             panel.addEventListener('dragover', e => e.preventDefault());


### PR DESCRIPTION
## Summary
- introduce paired layout PHP/CSS files using clip-path to describe horizontal, vertical, and diagonal panels
- keep style.css generic and load layout-specific styles dynamically in the builder
- embed layout CSS and slot images into PDF exports

## Testing
- `php -l app/Models/ComicModel.php`
- `php -l app/Controllers/ComicController.php`
- `php -l app/Views/index.php`
- `php -l layouts/one-panel.php`
- `php -l layouts/two-panel-horizontal.php`
- `php -l layouts/two-panel-vertical.php`
- `php -l layouts/three-panel.php`
- `npm test` *(fails: Could not read package.json)*
- `composer test` *(fails: Command "test" is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_6891513e3dbc832a96b361b7fe4bf269