### PR TITLE
Add responsive layout previews with transform-aware export

### DIFF
--- a/app/Controllers/ComicController.php
+++ b/app/Controllers/ComicController.php
@@ -64,7 +64,15 @@ class ComicController
         foreach ($pages as $page) {
             $layout = $page['layout'] ?? '';
             $slots = $page['slots'] ?? [];
-            $html .= $this->model->renderLayout($layout, $slots);
+            $transforms = [];
+            if (!empty($page['transforms']) && is_array($page['transforms'])) {
+                foreach ($page['transforms'] as $slot => $json) {
+                    if (is_string($json)) {
+                        $transforms[$slot] = json_decode($json, true) ?? [];
+                    }
+                }
+            }
+            $html .= $this->model->renderLayout($layout, $slots, $transforms);
         }
         $dompdf = new Dompdf(['isRemoteEnabled' => true]);
         $dompdf->loadHtml($html);

--- a/app/Models/ComicModel.php
+++ b/app/Models/ComicModel.php
@@ -127,7 +127,7 @@ class ComicModel
         $this->saveState();
     }
 
-    public function renderLayout(string $layout, array $slots): string
+    public function renderLayout(string $layout, array $slots, array $transforms = []): string
     {
         $file = $this->layoutDir . '/' . $layout . '.php';
         $cssFile = $this->layoutDir . '/' . $layout . '.css';
@@ -150,6 +150,13 @@ class ComicModel
             if ($nodes->length) {
                 $img = $dom->createElement('img');
                 $img->setAttribute('src', '/uploads/' . $image);
+                if (isset($transforms[$index])) {
+                    $t = $transforms[$index];
+                    $scale = $t['scale'] ?? 1;
+                    $tx = $t['translateX'] ?? 0;
+                    $ty = $t['translateY'] ?? 0;
+                    $img->setAttribute('style', 'transform: translate(' . $tx . 'px, ' . $ty . 'px) scale(' . $scale . ');');
+                }
                 $nodes->item(0)->appendChild($img);
             }
         }

--- a/layouts/three-panel.css
+++ b/layouts/three-panel.css
@@ -2,8 +2,8 @@
     clip-path: polygon(0 0, 50% 0, 50% 100%, 0 100%);
 }
 .layout.three-panel .panel2 {
-    clip-path: polygon(50% 0, 100% 0, 100% 100%);
+    clip-path: polygon(50% 0, 100% 0, 100% 100%, 50% 0);
 }
 .layout.three-panel .panel3 {
-    clip-path: polygon(50% 0, 100% 100%, 50% 100%);
+    clip-path: polygon(50% 0, 100% 100%, 50% 100%, 50% 0);
 }

--- a/public/css/style.css
+++ b/public/css/style.css
@@ -42,12 +42,14 @@ body {
 
 .layout-container {
     position: relative;
-    width: 400px;
-    height: 400px;
+    width: 100%;
+    aspect-ratio: 1 / 1.414; /* A4 ratio */
 }
 
 .layout {
-    position: relative;
+    position: absolute;
+    top: 0;
+    left: 0;
     width: 100%;
     height: 100%;
 }
@@ -72,8 +74,8 @@ body {
 }
 
 .panel img {
-    max-width: 100%;
-    max-height: 100%;
+    max-width: none;
+    max-height: none;
     cursor: move;
     user-select: none;
     transition: transform 0.1s ease-out;


### PR DESCRIPTION
## Summary
- Make layout panels responsive and move layout-specific geometry into dedicated PHP/CSS files
- Enhance client-side layout rendering with draggable, scalable image slots and persistence of transforms
- Export pages using stored layout metadata and transforms for PDF generation

## Testing
- `php -l app/Models/ComicModel.php`
- `php -l app/Controllers/ComicController.php`


------
https://chatgpt.com/codex/tasks/task_e_689153c54160832a80975e2e690fa75b