### PR TITLE
feat: support multiple image uploads

### DIFF
--- a/app/Controllers/ComicController.php
+++ b/app/Controllers/ComicController.php
@@ -37,7 +37,20 @@ class ComicController
     {
         header('Content-Type: application/json');
         try {
-            if (!empty($_FILES['image']['tmp_name'])) {
+            if (!empty($_FILES['images']['tmp_name'])) {
+                foreach ($_FILES['images']['tmp_name'] as $i => $tmp) {
+                    if ($_FILES['images']['error'][$i] === UPLOAD_ERR_OK) {
+                        $file = [
+                            'name' => $_FILES['images']['name'][$i],
+                            'type' => $_FILES['images']['type'][$i],
+                            'tmp_name' => $tmp,
+                            'error' => $_FILES['images']['error'][$i],
+                            'size' => $_FILES['images']['size'][$i],
+                        ];
+                        $this->model->saveUpload($file);
+                    }
+                }
+            } elseif (!empty($_FILES['image']['tmp_name'])) {
                 $this->model->saveUpload($_FILES['image']);
             }
             echo json_encode($this->model->getImages());

--- a/app/Views/index.php
+++ b/app/Views/index.php
@@ -10,7 +10,7 @@
 <div id="container">
     <div id="images">
         <form id="uploadForm" enctype="multipart/form-data">
-            <input type="file" name="image" id="imageInput" />
+            <input type="file" name="images[]" id="imageInput" multiple />
             <button type="submit">Upload</button>
         </form>
         <div id="imageList">

--- a/public/js/app.js
+++ b/public/js/app.js
@@ -264,10 +264,16 @@ window.addEventListener('DOMContentLoaded', () => {
 
     document.getElementById('uploadForm').addEventListener('submit', e => {
         e.preventDefault();
-        const formData = new FormData(e.target);
+        const input = document.getElementById('imageInput');
+        if (!input.files.length) return;
+        const formData = new FormData();
+        Array.from(input.files).forEach(file => formData.append('images[]', file));
         fetch('/upload', {method: 'POST', body: formData})
             .then(r => r.json())
-            .then(updateImages);
+            .then(updateImages)
+            .finally(() => {
+                input.value = '';
+            });
     });
 
     function updateImages(list) {


### PR DESCRIPTION
## Summary
- allow selecting multiple images in the upload form
- send all selected files in one request and reset the input
- process multiple uploads server-side

## Testing
- `php -l app/Views/index.php`
- `php -l app/Controllers/ComicController.php`
- `node --check public/js/app.js`
- `composer validate --no-check-lock`


------
https://chatgpt.com/codex/tasks/task_e_689181ea57b4832ab00dda017b70d289