### PR TITLE
Enable deleting images from image list

### DIFF
--- a/app/Models/ComicModel.php
+++ b/app/Models/ComicModel.php
@@ -85,6 +85,12 @@ class ComicModel
         if (is_file($path)) {
             unlink($path);
         }
+        // Remove from state and persist
+        $this->state['images'] = array_values(array_filter(
+            $this->state['images'],
+            fn($img) => $img !== $name
+        ));
+        $this->saveState();
     }
 
     public function getLayouts(): array

--- a/app/Views/index.php
+++ b/app/Views/index.php
@@ -13,11 +13,7 @@
             <input type="file" name="images[]" id="imageInput" multiple />
             <button type="submit">Upload</button>
         </form>
-        <div id="imageList">
-            <?php foreach ($images as $img): ?>
-                <img src="/uploads/<?= htmlspecialchars($img) ?>" class="thumb" draggable="true" data-name="<?= htmlspecialchars($img) ?>" />
-            <?php endforeach; ?>
-        </div>
+        <div id="imageList"></div>
     </div>
     <div id="builder">
         <button id="addPage" type="button">Add Page</button>
@@ -30,6 +26,7 @@ const layouts = <?= json_encode(array_keys($layouts)) ?>;
 const layoutTemplates = <?= json_encode($templates) ?>;
 const layoutStyles = <?= json_encode($styles) ?>;
 const savedPages = <?= json_encode($pages) ?>;
+const initialImages = <?= json_encode($images) ?>;
 </script>
 <!-- html2canvas and jsPDF CDN -->
 <script src="https://cdn.jsdelivr.net/npm/html2canvas@1.4.1/dist/html2canvas.min.js"></script>

--- a/public/js/app.js
+++ b/public/js/app.js
@@ -319,6 +319,8 @@ window.addEventListener('DOMContentLoaded', () => {
         });
     }
 
+    // Initialize with any images provided by the server
+    updateImages(typeof initialImages !== 'undefined' ? initialImages : []);
 
     // Removed comicForm submit handler since the form no longer exists
 


### PR DESCRIPTION
## Summary
- Render initial images with a delete button and server call for removal
- Initialize front-end image list with server-provided data
- Keep image state synchronized when files are deleted

## Testing
- `php -l app/Views/index.php`
- `php -l app/Models/ComicModel.php`
- `node --check public/js/app.js`


------
https://chatgpt.com/codex/tasks/task_e_689185fb4b74832aa2c6135567de821b