### PR TITLE
Load images before restoring pages and expose pages API

### DIFF
--- a/app/Controllers/ComicController.php
+++ b/app/Controllers/ComicController.php
@@ -28,6 +28,24 @@ class ComicController
     $input = file_get_contents('php://input');
     $data = json_decode($input, true);
     $pages = $data['pages'] ?? [];
+    // Preserve associative slot keys by converting to objects
+    foreach ($pages as &$page) {
+        if (isset($page['slots']) && is_array($page['slots'])) {
+            $slots = new \stdClass();
+            foreach ($page['slots'] as $k => $v) {
+                $slots->{(string)$k} = $v;
+            }
+            $page['slots'] = $slots;
+        }
+        if (isset($page['transforms']) && is_array($page['transforms'])) {
+            $transforms = new \stdClass();
+            foreach ($page['transforms'] as $k => $v) {
+                $transforms->{(string)$k} = $v;
+            }
+            $page['transforms'] = $transforms;
+        }
+    }
+    unset($page);
     $this->model->setPages($pages);
     header('Content-Type: application/json');
     echo json_encode(['status' => 'ok']);
@@ -104,5 +122,11 @@ class ComicController
         $this->model->saveState();
         header('Content-Type: application/json');
         echo json_encode(['file' => $filename]);
+    }
+
+    public function getPages(): void
+    {
+        header('Content-Type: application/json');
+        echo json_encode(['pages' => $this->model->getPages()]);
     }
 }

--- a/app/Core/Router.php
+++ b/app/Core/Router.php
@@ -14,6 +14,7 @@ class Router
             $r->addRoute('POST', '/upload', ['ComicController', 'handleUpload']);
             $r->addRoute('POST', '/delete-image', ['ComicController', 'deleteImage']);
             $r->addRoute('POST', '/save-pages', ['ComicController', 'savePages']);
+            $r->addRoute('GET', '/get-pages', ['ComicController', 'getPages']);
         });
     }
 }

--- a/app/Views/index.php
+++ b/app/Views/index.php
@@ -45,31 +45,6 @@ const layoutTemplates = <?= json_encode($templates) ?>;
 const layoutStyles = <?= json_encode($styles) ?>;
 const savedPages = <?= json_encode($pages) ?>;
     const initialImages = <?= json_encode($images) ?>;
-    // On page load, restore images to their assigned panels
-    window.addEventListener('DOMContentLoaded', () => {
-        if (savedPages && Array.isArray(savedPages)) {
-            savedPages.forEach((page, pageIdx) => {
-                if (page.slots && Array.isArray(page.slots)) {
-                    page.slots.forEach((imgName, slotIdx) => {
-                        if (imgName) {
-                            // Find the panel element for this page and slot
-                            const panel = document.querySelector(`[data-page="${pageIdx}"][data-slot="${slotIdx}"]`);
-                            if (panel) {
-                                // Create image element and add to panel
-                                const img = document.createElement('img');
-                                img.src = `/uploads/${imgName}`;
-                                img.className = 'thumb';
-                                img.draggable = true;
-                                img.dataset.name = imgName;
-                                panel.innerHTML = '';
-                                panel.appendChild(img);
-                            }
-                        }
-                    });
-                }
-            });
-        }
-    });
 </script>
 <!-- html2canvas and jsPDF CDN -->
 <script src="https://cdn.jsdelivr.net/npm/html2canvas@1.4.1/dist/html2canvas.min.js"></script>

--- a/public/js/app.js
+++ b/public/js/app.js
@@ -8,7 +8,7 @@
             const slots = {};
             const transforms = {};
             pageDiv.querySelectorAll('.panel').forEach(panel => {
-                const slot = panel.getAttribute('data-slot');
+                const slot = String(panel.getAttribute('data-slot'));
                 const img = panel.querySelector('img');
                 if (img) {
                     slots[slot] = img.dataset.name;
@@ -48,6 +48,9 @@
 window.addEventListener('DOMContentLoaded', () => {
     const imageList = document.getElementById('imageList');
     let pageCounter = 0;
+
+    // Load all images before restoring any pages
+    updateImages(typeof initialImages !== 'undefined' ? initialImages : [], []);
 
     function enableImageControls(img, hiddenInput, initial = {}) {
         let scale = parseFloat(initial.scale || 1);
@@ -383,9 +386,6 @@ window.addEventListener('DOMContentLoaded', () => {
             }
         });
     }
-
-    // Initialize with any images provided by the server and savedPages
-    updateImages(typeof initialImages !== 'undefined' ? initialImages : [], savedPages);
 
     // Removed comicForm submit handler since the form no longer exists
 


### PR DESCRIPTION
## Summary
- Initialize image list before creating pages and use string slot keys when saving state
- Remove server-side DOMContentLoaded restoration; app.js handles restored pages
- Add `GET /get-pages` API route and preserve slot keys when saving pages

## Testing
- `node --check public/js/app.js`
- `php -l app/Controllers/ComicController.php`
- `php -l app/Core/Router.php`
- `php -l app/Views/index.php`


------
https://chatgpt.com/codex/tasks/task_e_6891911d3bac832a8181ef58927e94c0