### PR TITLE
chore: remove server-side pdf remnants

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,4 +14,4 @@ A simple MVC PHP application that lets you drag and drop uploaded images into pr
    ```
 3. Open `http://localhost:8000` in your browser.
 
-Uploaded images are stored in `uploads/` and generated PDFs appear in `storage/generated/`.
+Uploaded images are stored in `uploads/`.

--- a/app/Models/ComicModel.php
+++ b/app/Models/ComicModel.php
@@ -5,7 +5,6 @@ class ComicModel
 {
     public string $uploadDir;
     public string $layoutDir;
-    public string $generatedDir;
     private string $stateFile;
     private array $state = [
         'images' => [],
@@ -17,7 +16,6 @@ class ComicModel
     {
         $this->uploadDir = __DIR__ . '/../../public/uploads';
         $this->layoutDir = __DIR__ . '/../../layouts';
-        $this->generatedDir = __DIR__ . '/../../public/generated';
         $this->stateFile = __DIR__ . '/../../public/storage/state.json';
         if (!is_dir($this->uploadDir)) {
             mkdir($this->uploadDir, 0777, true);


### PR DESCRIPTION
## Summary
- drop unused generatedDir from ComicModel
- clean README of server-side PDF mentions

## Testing
- `php -l app/Models/ComicModel.php`
- `composer validate --no-check-publish`


------
https://chatgpt.com/codex/tasks/task_e_6892058df380832a8bd58bf99dca63d4