### PR TITLE
Revamp interface with modern layout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
 ## [Unreleased]
+### Changed
+- Rebuilt the entire interface with a modern glassmorphism aesthetic, refreshed typography, and responsive layout cards to separate the asset library from the page builder.
+
 ### Fixed
 - Preserve diagonal panel shapes in exported images and PDFs by post-processing html2canvas output with the layout's clip-path data.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,14 @@
 # Comic Layout Designer
 
-A simple MVC PHP application that lets you drag and drop uploaded images into predefined comic page layouts and export the result to PDF.
+A modern MVC PHP application for crafting comic spreads. Upload artwork, drag it into responsive layout templates, and export the finished pages as high-resolution PDFs or images.
+
+## Features
+
+- **Curated asset library** – Upload multiple images at once and manage them with quick delete actions.
+- **Storyboard workspace** – Drag panels into dynamic templates, adjust gutter colors, and fine-tune each panel's zoom and position.
+- **Live autosave** – Progress is preserved automatically, with inline feedback to confirm every change.
+- **One-click exports** – Generate PDFs or high-quality image sets directly from the browser.
+- **Keyboard shortcuts** – Stay in flow with quick commands for saving, creating pages, and exporting.
 
 ## Setup
 
@@ -14,9 +22,22 @@ A simple MVC PHP application that lets you drag and drop uploaded images into pr
    ```
 3. Open `http://localhost:8000` in your browser.
 
-Uploaded images are stored in `uploads/`.
+Uploaded images are stored in `public/uploads/`. Generated exports live in `public/storage/generated/`.
+
+## Keyboard Shortcuts
+
+| Shortcut | Action |
+| --- | --- |
+| `Ctrl` + `S` | Save the current project |
+| `Ctrl` + `N` | Add a new page |
+| `Ctrl` + `E` | Export as PDF |
+| `Ctrl` + `I` | Export as PNG images |
+| Mouse scroll | Zoom in/out on a placed image |
+
+## Modernized interface
+
+The refreshed UI introduces a glassmorphism-inspired surface layered over a deep gradient backdrop. Responsive cards separate the asset library from the workspace, while updated typography and spacing improve readability across screen sizes. Buttons and controls now share a consistent accent color palette, and empty states provide clear guidance for first-time users.
 
 ## Notes
 
-* Exported PDFs and PNGs now keep the diagonal panel edges found in the angled layouts. The exporter re-applies each layout's
-  `clip-path` geometry after html2canvas renders the page so the gutters stay crisp in the output files.
+* Exported PDFs and PNGs keep the diagonal panel edges found in the angled layouts. The exporter re-applies each layout's `clip-path` geometry after html2canvas renders the page so the gutters stay crisp in the output files.

--- a/app/Views/index.php
+++ b/app/Views/index.php
@@ -1,40 +1,77 @@
 <?php /** @var array $images */ ?>
 <!DOCTYPE html>
-<html>
+<html lang="en">
 <head>
     <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>Comic Layout Designer</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="/css/style.css" />
 </head>
 <body>
-<div id="container">
-    <div id="images">
-        <form id="uploadForm" enctype="multipart/form-data">
-            <input type="file" name="images[]" id="imageInput" multiple />
-            <button type="submit">Upload</button>
-        </form>
-        <div id="imageList">
-            <!-- Images will be loaded by JavaScript -->
+<div class="app-shell">
+    <header class="app-header">
+        <div class="brand">
+            <span class="brand-mark">V</span>
+            <div class="brand-copy">
+                <h1>Comic Layout Designer</h1>
+                <p>Craft beautifully balanced comic pages with a responsive, distraction-free workspace.</p>
+            </div>
         </div>
-    </div>
-    <div id="builder">
-        <div style="display: flex; align-items: center; gap: 16px; margin-bottom: 10px;">
-            <button id="addPage" type="button">Add Page</button>
-            <small style="color: #666; font-style: italic;">
-                💡 Tips: Ctrl+S to save, Ctrl+N for new page, Ctrl+E to export PDF, Ctrl+I to export images, Ctrl+D to debug layouts, scroll wheel to zoom images
-            </small>
+        <div class="header-actions">
+            <button id="exportPdf" type="button" class="ghost">Export PDF</button>
+            <button id="exportImages" type="button" class="ghost">Export Images</button>
         </div>
-        <div id="pages"></div>
-        <button id="exportPdf" type="button" style="margin-top:16px;">Export PDF</button>
-        <button id="exportImages" type="button" style="margin-top:16px; margin-left:10px;">Export Images</button>
-    </div>
+    </header>
+    <main class="app-main">
+        <section id="images" aria-label="Image library">
+            <div class="card-header">
+                <div>
+                    <h2>Asset Library</h2>
+                    <p class="subtitle">Upload, curate, and reuse artwork across your spreads.</p>
+                </div>
+            </div>
+            <form id="uploadForm" enctype="multipart/form-data">
+                <label for="imageInput" class="field-label">Upload artwork</label>
+                <input type="file" name="images[]" id="imageInput" multiple />
+                <button type="submit" class="primary">Add to library</button>
+            </form>
+            <div id="imageList" aria-live="polite">
+                <div class="empty-state" data-placeholder>
+                    <span class="icon">🖼️</span>
+                    <p>Drop panels into your story by uploading artwork.</p>
+                </div>
+            </div>
+        </section>
+        <section id="builder" aria-label="Page builder">
+            <div class="workspace-toolbar">
+                <div>
+                    <h2>Storyboard Workspace</h2>
+                    <p class="subtitle">Arrange layouts, fine-tune gutters, and drag assets into each panel.</p>
+                </div>
+                <div class="toolbar-actions">
+                    <button id="addPage" type="button" class="primary">Add Page</button>
+                </div>
+            </div>
+            <ul class="shortcuts">
+                <li><span>Ctrl + S</span>Quick save</li>
+                <li><span>Ctrl + N</span>New page</li>
+                <li><span>Ctrl + E</span>Export PDF</li>
+                <li><span>Ctrl + I</span>Export images</li>
+                <li><span>Scroll</span>Zoom artwork</li>
+            </ul>
+            <div id="pages"></div>
+        </section>
+    </main>
 </div>
 <script>
 const layouts = <?= json_encode(array_keys($layouts)) ?>;
 const layoutTemplates = <?= json_encode($templates) ?>;
 const layoutStyles = <?= json_encode($styles) ?>;
 const savedPages = <?= json_encode($pages) ?>;
-    const initialImages = <?= json_encode($images) ?>;
+const initialImages = <?= json_encode($images) ?>;
 </script>
 <!-- html2canvas and jsPDF CDN -->
 <script src="https://cdn.jsdelivr.net/npm/html2canvas@1.4.1/dist/html2canvas.min.js"></script>

--- a/public/css/style.css
+++ b/public/css/style.css
@@ -1,338 +1,474 @@
-/* Remove border and style file input */
-#imageInput {
-    width: 100%;
+:root {
+    color-scheme: light;
+    --bg-gradient: radial-gradient(circle at top, #1e40af 0%, #0f172a 45%, #020617 100%);
+    --surface: rgba(15, 23, 42, 0.72);
+    --surface-alt: rgba(15, 23, 42, 0.58);
+    --border: rgba(148, 163, 184, 0.25);
+    --accent: #6366f1;
+    --accent-strong: #4338ca;
+    --accent-soft: rgba(99, 102, 241, 0.18);
+    --danger: #ef4444;
+    --text-primary: #e2e8f0;
+    --text-muted: #94a3b8;
+    --shadow-soft: 0 20px 60px -30px rgba(15, 23, 42, 0.75);
+    --shadow-focus: 0 8px 28px rgba(99, 102, 241, 0.45);
+    --radius-lg: 24px;
+    --radius-md: 16px;
+    --radius-sm: 12px;
+    --transition: 180ms ease;
+    font-family: "Inter", system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+}
+
+* {
     box-sizing: border-box;
-    border: none;
-    background: transparent;
-    box-shadow: none;
-}
-
-/* Style the 'Choose files' button */
-#imageInput::-webkit-file-upload-button {
-    background: linear-gradient(90deg, #ffe6b0 0%, #ffd966 100%);
-    color: #222;
-    font-weight: bold;
-    border-radius: 8px;
-    border: 2px solid #e09c2b;
-    box-shadow: none;
-    padding: 8px 18px;
-    font-size: 16px;
-    cursor: pointer;
-    transition: background 0.2s, border-color 0.2s;
-}
-
-#imageInput::-webkit-file-upload-button:hover,
-#imageInput::-webkit-file-upload-button:focus {
-    background: linear-gradient(90deg, #ffd966 0%, #ffe6b0 100%);
-    border-color: #222;
-    box-shadow: none;
-}
-
-/* Firefox */
-#imageInput::file-selector-button {
-    background: linear-gradient(90deg, #ffe6b0 0%, #ffd966 100%);
-    color: #222;
-    font-weight: bold;
-    border-radius: 8px;
-    border: 2px solid #e09c2b;
-    box-shadow: none;
-    padding: 8px 18px;
-    font-size: 16px;
-    cursor: pointer;
-    transition: background 0.2s, border-color 0.2s;
-}
-
-#imageInput::file-selector-button:hover,
-#imageInput::file-selector-button:focus {
-    background: linear-gradient(90deg, #ffd966 0%, #ffe6b0 100%);
-    border-color: #222;
-    box-shadow: none;
-}
-
-/* Gutter color picker styled like select */
-.gutter-color-picker {
-    appearance: none;
-    -webkit-appearance: none;
-    -moz-appearance: none;
-    background: #fff;
-    border: 2px solid #e09c2b;
-    border-radius: 8px;
-    padding: 6px 6px 6px 6px;
-    width: 40px;
-    height: 40px;
-    box-shadow: 0 2px 8px rgba(224, 156, 43, 0.1);
-    cursor: pointer;
-    outline: none;
-    margin-right: 8px;
-    transition: border-color 0.2s, box-shadow 0.2s;
-    vertical-align: middle;
-}
-
-.gutter-color-picker:focus {
-    border-color: #222;
-    box-shadow: 0 0 0 2px #ffe6b0;
-}
-
-/* Align Upload button to the right */
-#uploadForm {
-    border: 2px solid #222;
-    background: #fff;
-    border-radius: 12px;
-    box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
-    padding: 12px;
-    margin-bottom: 18px;
-    display: flex;
-    justify-content: flex-end;
-    gap: 12px;
-}
-
-/* Use grid for better image layout */
-/* Use flexbox for 3 images per row */
-/* Flexbox, 3 large images per row */
-/* Flexbox, 3 images per row, fill container */
-/* Flexbox, 3 images per row, reliable layout */
-/* Grid, 3 columns for image list */
-#imageList {
-    border: 2px solid #222;
-    background: #fff;
-    border-radius: 12px;
-    box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
-    padding: 12px;
-    height: 90%;
-    overflow-y: auto;
-    display: grid;
-    grid-template-columns: repeat(3, 1fr);
-    gap: 12px;
-}
-
-/* Image wrapper fills grid cell */
-.image-wrapper {
-    width: 100%;
-    height: 100%;
-    display: flex;
-    flex-direction: column;
-}
-
-.delete-image-btn {
-    background: linear-gradient(90deg, #ffb3b3 0%, #ff6666 100%);
-    color: #fff;
-    font-weight: bold;
-    border-radius: 8px;
-    border: 2px solid #c00;
-    box-shadow: 0 2px 8px rgba(255, 0, 0, 0.1);
-    padding: 4px 10px;
-    font-size: 16px;
-    margin-top: 4px;
-    cursor: pointer;
-    transition: background 0.2s, border-color 0.2s, box-shadow 0.2s;
-}
-
-.delete-image-btn:hover,
-.delete-image-btn:focus {
-    background: linear-gradient(90deg, #ff6666 0%, #ffb3b3 100%);
-    border-color: #222;
-    box-shadow: 0 4px 16px rgba(255, 0, 0, 0.18);
-}
-
-/* Delete Page Button Styles */
-.delete-page-btn {
-    background: linear-gradient(90deg, #ffb3b3 0%, #ff6666 100%);
-    color: #fff;
-    font-weight: bold;
-    border-radius: 12px;
-    border: 2px solid #c00;
-    box-shadow: 0 2px 8px rgba(255, 0, 0, 0.1);
-    padding: 8px 18px;
-    font-size: 16px;
-    letter-spacing: 1px;
-    margin-bottom: 8px;
-    margin-top: 4px;
-    float: right;
-    cursor: pointer;
-    transition: background 0.2s, border-color 0.2s, box-shadow 0.2s;
-}
-
-.delete-page-btn:hover,
-.delete-page-btn:focus {
-    background: linear-gradient(90deg, #ff6666 0%, #ffb3b3 100%);
-    border-color: #222;
-    box-shadow: 0 4px 16px rgba(255, 0, 0, 0.18);
 }
 
 body {
-    font-family: Arial, sans-serif;
     margin: 0;
-    padding: 0;
-    background: #f5f3e7;
-}
-
-#container {
+    min-height: 100vh;
+    background: var(--bg-gradient);
+    color: var(--text-primary);
     display: flex;
-    width: 100vw;
-    height: 100vh;
+    justify-content: center;
+    font-family: inherit;
 }
 
-#images {
-    width: 30%;
-    padding: 10px;
-    border-right: 1px solid #ccc;
-    overflow-y: auto;
-    height: 98vh;
+.app-shell {
+    width: min(1380px, 100%);
+    min-height: 100vh;
+    display: flex;
+    flex-direction: column;
+    padding: 24px clamp(16px, 3vw, 48px) 32px;
+    gap: 28px;
+}
+
+.app-header {
+    display: flex;
+    flex-wrap: wrap;
+    justify-content: space-between;
+    align-items: center;
+    gap: 24px;
+    background: var(--surface);
+    border: 1px solid var(--border);
+    border-radius: var(--radius-lg);
+    padding: 28px clamp(24px, 4vw, 48px);
+    box-shadow: var(--shadow-soft);
+    backdrop-filter: blur(18px);
+}
+
+.brand {
+    display: flex;
+    align-items: center;
+    gap: 20px;
+}
+
+.brand-mark {
+    display: inline-grid;
+    place-items: center;
+    width: 58px;
+    height: 58px;
+    border-radius: 18px;
+    background: linear-gradient(140deg, var(--accent), var(--accent-strong));
+    font-weight: 700;
+    font-size: 28px;
+    letter-spacing: 1px;
+    color: white;
+    box-shadow: 0 18px 40px -24px var(--accent-strong);
+}
+
+.brand-copy h1 {
+    margin: 0 0 6px;
+    font-size: clamp(1.75rem, 3vw, 2.4rem);
+    font-weight: 600;
+}
+
+.brand-copy p {
+    margin: 0;
+    color: var(--text-muted);
+    max-width: 520px;
+    font-size: 0.95rem;
+}
+
+.header-actions {
+    display: flex;
+    gap: 12px;
+    flex-wrap: wrap;
+}
+
+.app-main {
+    display: grid;
+    grid-template-columns: minmax(280px, 340px) 1fr;
+    gap: 28px;
+    width: 100%;
+}
+
+@media (max-width: 1180px) {
+    .app-main {
+        grid-template-columns: 1fr;
+    }
+
+    #images {
+        order: 2;
+    }
+}
+
+#images,
+#builder {
+    background: var(--surface-alt);
+    border: 1px solid var(--border);
+    border-radius: var(--radius-lg);
+    box-shadow: var(--shadow-soft);
+    backdrop-filter: blur(18px);
+    padding: clamp(20px, 3vw, 32px);
+    display: flex;
+    flex-direction: column;
+    gap: 24px;
+    min-height: 0;
+}
+
+.card-header h2,
+.workspace-toolbar h2 {
+    margin: 0 0 6px;
+    font-size: 1.35rem;
+    font-weight: 600;
+}
+
+.subtitle {
+    margin: 0;
+    color: var(--text-muted);
+    font-size: 0.95rem;
+}
+
+#uploadForm {
+    display: grid;
+    gap: 14px;
+    background: rgba(15, 23, 42, 0.55);
+    border: 1px solid rgba(148, 163, 184, 0.2);
+    border-radius: var(--radius-md);
+    padding: 18px 20px 20px;
+}
+
+.field-label {
+    font-size: 0.85rem;
+    letter-spacing: 0.06em;
+    text-transform: uppercase;
+    color: var(--text-muted);
 }
 
 input,
 select,
 textarea,
 button {
-    font-family: Comic Sans MS, Comic Neue, Arial, sans-serif;
-    font-size: 16px;
-    border: 2px solid #222;
-    border-radius: 6px;
-    background: #fff;
-    color: #222;
-    padding: 8px 12px;
-    margin: 4px 0;
-    box-shadow: 0 2px 8px rgba(0, 0, 0, 0.08);
-    outline: none;
-    transition: border-color 0.2s, box-shadow 0.2s;
+    font-family: inherit;
 }
 
-input:focus,
-select:focus,
-textarea:focus,
-button:focus {
-    border-color: #e09c2b;
-    box-shadow: 0 0 0 2px #ffe6b0;
-}
-
-button {
-    background: linear-gradient(90deg, #ffe6b0 0%, #ffd966 100%);
-    color: #222;
-    font-weight: bold;
+input[type="file"] {
+    width: 100%;
+    background: rgba(15, 23, 42, 0.85);
+    color: var(--text-muted);
+    padding: 12px;
+    border: 1px dashed rgba(148, 163, 184, 0.35);
+    border-radius: var(--radius-sm);
+    transition: border var(--transition), color var(--transition), background var(--transition);
     cursor: pointer;
-    border-radius: 12px;
-    border: 3px solid #e09c2b;
-    box-shadow: 0 4px 16px rgba(224, 156, 43, 0.15);
-    padding: 12px 28px;
-    letter-spacing: 1px;
-    font-size: 18px;
-    text-transform: uppercase;
-    transition: background 0.2s, border-color 0.2s, box-shadow 0.2s;
+}
+
+input[type="file"]:focus,
+input[type="file"]:hover {
+    border-color: var(--accent);
+    color: var(--text-primary);
+    background: rgba(37, 99, 235, 0.15);
     outline: none;
 }
 
-button:hover,
-button:focus {
-    background: linear-gradient(90deg, #ffd966 0%, #ffe6b0 100%);
-    border-color: #222;
-    box-shadow: 0 6px 24px rgba(224, 156, 43, 0.25);
-}
-
-select {
-    appearance: none;
-    -webkit-appearance: none;
-    -moz-appearance: none;
-    background: #fff;
-    border: 2px solid #e09c2b;
-    border-radius: 8px;
-    padding: 10px 36px 10px 12px;
-    font-size: 16px;
-    color: #222;
-    box-shadow: 0 2px 8px rgba(224, 156, 43, 0.1);
-    cursor: pointer;
-    outline: none;
-    position: relative;
-}
-
-select:focus {
-    border-color: #222;
-    box-shadow: 0 0 0 2px #ffe6b0;
-}
-
-select::-ms-expand {
+#imageInput::-webkit-file-upload-button {
     display: none;
 }
 
-/* Custom arrow for select */
-select {
-    background-image: url('data:image/svg+xml;utf8,<svg fill="%23222" height="16" viewBox="0 0 24 24" width="16" xmlns="http://www.w3.org/2000/svg"><path d="M7 10l5 5 5-5z"/></svg>');
-    background-repeat: no-repeat;
-    background-position: right 12px center;
-    background-size: 18px 18px;
+#imageInput::file-selector-button {
+    display: none;
 }
 
-#builder {
-    flex: 1;
-    padding: 10px;
+.gutter-color-picker {
+    padding: 0;
+    width: 48px;
+    height: 48px;
+    border-radius: 14px;
+    cursor: pointer;
+}
+
+button {
+    border: 0;
+    border-radius: var(--radius-sm);
+    padding: 12px 20px;
+    font-size: 0.95rem;
+    font-weight: 600;
+    letter-spacing: 0.02em;
+    transition: transform var(--transition), box-shadow var(--transition), background var(--transition);
+    cursor: pointer;
+}
+
+button.primary {
+    background: linear-gradient(135deg, var(--accent), var(--accent-strong));
+    color: white;
+    box-shadow: 0 14px 30px -20px var(--accent-strong);
+}
+
+button.primary:hover,
+button.primary:focus {
+    transform: translateY(-2px);
+    box-shadow: var(--shadow-focus);
+    outline: none;
+}
+
+button.ghost {
+    background: rgba(99, 102, 241, 0.08);
+    color: var(--text-primary);
+    border: 1px solid rgba(99, 102, 241, 0.2);
+}
+
+button.ghost:hover,
+button.ghost:focus {
+    background: rgba(99, 102, 241, 0.18);
+    border-color: rgba(99, 102, 241, 0.4);
+    transform: translateY(-1px);
+    outline: none;
+}
+
+#imageList {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(120px, 1fr));
+    gap: 16px;
+    background: rgba(15, 23, 42, 0.55);
+    border-radius: var(--radius-md);
+    border: 1px solid rgba(148, 163, 184, 0.18);
+    padding: 20px;
     overflow-y: auto;
+    min-height: 220px;
+}
+
+.image-wrapper {
+    position: relative;
+    background: rgba(15, 23, 42, 0.65);
+    border-radius: var(--radius-sm);
+    border: 1px solid rgba(148, 163, 184, 0.25);
+    padding: 8px;
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+    transition: transform var(--transition), box-shadow var(--transition);
+}
+
+.image-wrapper:hover {
+    transform: translateY(-3px);
+    box-shadow: 0 18px 24px -22px rgba(15, 23, 42, 0.9);
+}
+
+.thumb {
+    width: 100%;
+    aspect-ratio: 1 / 1;
+    object-fit: cover;
+    border-radius: 10px;
+    background: rgba(15, 23, 42, 0.55);
+    cursor: grab;
+    transition: transform var(--transition), box-shadow var(--transition);
+}
+
+.thumb:hover {
+    transform: scale(1.03);
+    box-shadow: 0 12px 18px -16px rgba(99, 102, 241, 0.65);
+}
+
+.delete-image-btn,
+.delete-page-btn {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    gap: 6px;
+    font-size: 0.85rem;
+    padding: 10px 14px;
+    border-radius: var(--radius-sm);
+    background: rgba(239, 68, 68, 0.1);
+    color: #fecaca;
+    border: 1px solid rgba(239, 68, 68, 0.35);
+    transition: background var(--transition), border var(--transition), transform var(--transition);
+}
+
+.delete-page-btn {
+    align-self: flex-start;
+}
+
+.delete-page-btn span,
+.delete-image-btn span {
+    pointer-events: none;
+}
+
+.delete-image-btn:hover,
+.delete-image-btn:focus,
+.delete-page-btn:hover,
+.delete-page-btn:focus {
+    background: rgba(239, 68, 68, 0.2);
+    border-color: rgba(239, 68, 68, 0.5);
+    transform: translateY(-1px);
+    outline: none;
+}
+
+.workspace-toolbar {
+    display: flex;
+    flex-wrap: wrap;
+    justify-content: space-between;
+    align-items: center;
+    gap: 18px;
+}
+
+.shortcuts {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+    list-style: none;
+    padding: 0;
+    margin: 0;
+    gap: 12px;
+}
+
+.shortcuts li {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    background: rgba(15, 23, 42, 0.55);
+    border-radius: var(--radius-sm);
+    border: 1px solid rgba(148, 163, 184, 0.15);
+    padding: 12px 16px;
+    color: var(--text-muted);
+    font-size: 0.9rem;
+}
+
+.shortcuts span {
+    display: inline-flex;
+    min-width: 74px;
+    justify-content: center;
+    padding: 4px 8px;
+    border-radius: 999px;
+    background: rgba(99, 102, 241, 0.18);
+    color: var(--text-primary);
+    font-weight: 600;
+    font-size: 0.75rem;
 }
 
 #pages {
     display: grid;
-    grid-template-columns: repeat(2, 1fr);
-    gap: 20px;
-}
-
-
-.thumb {
-    width: 100%;
-    height: auto;
-    object-fit: cover;
-    margin: 0;
-    cursor: grab;
-    background: #fff;
+    gap: 24px;
+    grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
+    align-content: flex-start;
 }
 
 .page {
-    padding: 16px;
-    position: relative;
-    background: #fff;
-    border: 2px solid #222;
-    border-radius: 16px;
-    box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
-    margin: 8px;
+    background: rgba(15, 23, 42, 0.55);
+    border-radius: var(--radius-md);
+    border: 1px solid rgba(148, 163, 184, 0.2);
+    padding: 22px;
+    display: flex;
+    flex-direction: column;
+    gap: 18px;
+    box-shadow: 0 20px 40px -34px rgba(15, 23, 42, 1);
+}
+
+.page-controls {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: flex-start;
+    justify-content: space-between;
+    gap: 18px;
+}
+
+.page-meta {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: flex-end;
+    gap: 16px;
+}
+
+.input-group {
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+    font-size: 0.75rem;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    color: var(--text-muted);
+}
+
+.input-group span {
+    pointer-events: none;
+}
+
+.input-group select,
+.input-group input[type="color"],
+.page select,
+.page input[type="color"] {
+    background: rgba(15, 23, 42, 0.85);
+    border: 1px solid rgba(148, 163, 184, 0.28);
+    border-radius: var(--radius-sm);
+    color: var(--text-primary);
+    padding: 10px 14px;
+    min-width: 0;
+    transition: border var(--transition), box-shadow var(--transition);
+}
+
+.page select:focus,
+.page input[type="color"]:focus {
+    border-color: var(--accent);
+    box-shadow: 0 0 0 3px rgba(99, 102, 241, 0.18);
+    outline: none;
 }
 
 .layout-container {
     position: relative;
-    width: 528px;
-    /* 5.5in * 96dpi */
-    height: 816px;
-    /* 8.5in * 96dpi */
-    background: #fffbe6;
-    border: 2px solid #222;
-    box-shadow: 0 4px 16px rgba(0, 0, 0, 0.12);
+    width: 100%;
+    max-width: 528px;
+    aspect-ratio: 8.5 / 11;
+    margin: 0 auto;
+    border-radius: 20px;
+    border: 1px solid rgba(148, 163, 184, 0.2);
     overflow: hidden;
-    margin: auto;
+    background: linear-gradient(140deg, rgba(241, 245, 249, 0.95), rgba(226, 232, 240, 0.85));
+    box-shadow: 0 24px 45px -32px rgba(15, 23, 42, 0.9);
 }
 
 .layout {
     position: absolute;
-    top: 0;
-    left: 0;
+    inset: 0;
     width: 100%;
     height: 100%;
+    transition: background-color var(--transition);
 }
 
 .panel {
     position: absolute;
-    top: 0;
-    left: 0;
-    width: 100%;
-    height: 100%;
+    inset: 0;
     display: flex;
     align-items: center;
     justify-content: center;
     overflow: hidden;
     background: rgba(255, 255, 255, 0.85);
+    border-radius: 12px;
+    transition: background var(--transition), border var(--transition), transform 120ms ease-out;
+}
+
+.panel:hover {
+    background: rgba(255, 255, 255, 0.95);
+}
+
+.panel.drag-over {
+    border: 2px dashed rgba(99, 102, 241, 0.55);
+    background: rgba(99, 102, 241, 0.12);
 }
 
 .panel:empty::before {
-    content: "Drop image";
-    color: #999;
-    font-size: 14px;
-    font-family: Comic Sans MS, Comic Neue, Arial, sans-serif;
-    letter-spacing: 1px;
+    content: "Drop artwork";
+    font-size: 0.85rem;
+    letter-spacing: 0.1em;
+    text-transform: uppercase;
+    color: rgba(15, 23, 42, 0.35);
 }
 
 .panel img {
@@ -340,89 +476,38 @@ select {
     max-height: 100%;
     width: auto;
     height: auto;
-    cursor: move;
-    user-select: none;
-    transition: transform 0.05s ease-out; /* Faster, smoother transitions for live editing */
-    position: relative;
-    z-index: 1;
-}
-
-/* Live editing improvements */
-.panel {
-    position: absolute;
-    top: 0;
-    left: 0;
-    width: 100%;
-    height: 100%;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    overflow: hidden;
-    background: rgba(255, 255, 255, 0.85);
-    transition: background-color 0.2s ease; /* Smooth gutter color transitions */
-}
-
-.layout {
-    position: absolute;
-    top: 0;
-    left: 0;
-    width: 100%;
-    height: 100%;
-    transition: background-color 0.2s ease; /* Smooth gutter color transitions */
-}
-
-/* Visual feedback for drag operations */
-.panel:hover {
-    background: rgba(255, 255, 255, 0.95);
-}
-
-.panel.drag-over {
-    background: rgba(76, 175, 80, 0.1);
-    border: 2px dashed #4CAF50;
-    box-shadow: inset 0 0 10px rgba(76, 175, 80, 0.2);
-}
-
-/* Improved image thumbnails */
-.thumb {
-    width: 100%;
-    height: auto;
-    object-fit: cover;
-    margin: 0;
     cursor: grab;
-    background: #fff;
-    border-radius: 4px;
-    transition: transform 0.2s ease, box-shadow 0.2s ease;
+    user-select: none;
+    transition: transform 60ms ease-out;
 }
 
-.thumb:hover {
-    transform: scale(1.02);
-    box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
+.empty-state {
+    grid-column: 1 / -1;
+    padding: 28px;
+    border-radius: var(--radius-md);
+    border: 1px dashed rgba(148, 163, 184, 0.25);
+    background: rgba(15, 23, 42, 0.45);
+    display: grid;
+    gap: 12px;
+    justify-items: center;
+    color: var(--text-muted);
+    text-align: center;
 }
 
-.thumb:active {
-    cursor: grabbing;
-    transform: scale(0.98);
-}
-.gutter-color-picker {
-    appearance: none;
-    -webkit-appearance: none;
-    -moz-appearance: none;
-    background: #fff;
-    border: 2px solid #e09c2b;
-    border-radius: 8px;
-    padding: 6px 6px 6px 6px;
-    width: 40px;
-    height: 40px;
-    box-shadow: 0 2px 8px rgba(224, 156, 43, 0.1);
-    cursor: pointer;
-    outline: none;
-    margin-right: 8px;
-    transition: border-color 0.2s, box-shadow 0.2s, transform 0.1s;
-    vertical-align: middle;
+.empty-state .icon {
+    font-size: 2rem;
 }
 
-.gutter-color-picker:focus {
-    border-color: #222;
-    box-shadow: 0 0 0 2px #ffe6b0;
-    transform: scale(1.05);
+@media (max-width: 720px) {
+    .app-shell {
+        padding: 16px;
+    }
+
+    .app-header {
+        padding: 24px;
+    }
+
+    .shortcuts {
+        grid-template-columns: 1fr;
+    }
 }

--- a/public/js/app.js
+++ b/public/js/app.js
@@ -512,10 +512,7 @@ window.addEventListener("DOMContentLoaded", () => {
     const deleteBtn = document.createElement("button");
     deleteBtn.type = "button";
     deleteBtn.className = "delete-page-btn";
-    deleteBtn.textContent = "🗑 Delete Page";
-    deleteBtn.style.float = "right";
-    deleteBtn.style.marginLeft = "8px";
-    page.appendChild(deleteBtn);
+    deleteBtn.innerHTML = '<span aria-hidden="true">✕</span> Remove Page';
 
     // Layout selector
     const select = document.createElement("select");
@@ -525,7 +522,6 @@ window.addEventListener("DOMContentLoaded", () => {
       opt.textContent = l;
       select.appendChild(opt);
     });
-    select.style.marginRight = "8px";
 
     // Gutter color picker
     const gutterColor = document.createElement("input");
@@ -534,17 +530,25 @@ window.addEventListener("DOMContentLoaded", () => {
     gutterColor.title = "Gutter Color";
     gutterColor.className = "gutter-color-picker";
 
-    // Label for color picker
-    const gutterLabel = document.createElement("label");
-    gutterLabel.textContent = "Gutter Color: ";
-    gutterLabel.appendChild(gutterColor);
-    gutterLabel.style.marginRight = "8px";
+    const layoutGroup = document.createElement("label");
+    layoutGroup.className = "input-group";
+    layoutGroup.innerHTML = "<span>Layout</span>";
+    layoutGroup.appendChild(select);
+
+    const gutterGroup = document.createElement("label");
+    gutterGroup.className = "input-group";
+    gutterGroup.innerHTML = "<span>Gutter</span>";
+    gutterGroup.appendChild(gutterColor);
+
+    const meta = document.createElement("div");
+    meta.className = "page-meta";
+    meta.appendChild(layoutGroup);
+    meta.appendChild(gutterGroup);
 
     const controlsDiv = document.createElement("div");
-    controlsDiv.style.display = "flex";
-    controlsDiv.style.alignItems = "center";
-    controlsDiv.appendChild(select);
-    controlsDiv.appendChild(gutterLabel);
+    controlsDiv.className = "page-controls";
+    controlsDiv.appendChild(meta);
+    controlsDiv.appendChild(deleteBtn);
     page.appendChild(controlsDiv);
 
     const container = document.createElement("div");
@@ -685,6 +689,17 @@ window.addEventListener("DOMContentLoaded", () => {
     return assigned;
   }
 
+  function createImagePlaceholder() {
+    const placeholder = document.createElement("div");
+    placeholder.className = "empty-state";
+    placeholder.dataset.placeholder = "";
+    placeholder.innerHTML = `
+      <span class="icon" aria-hidden="true">🖼️</span>
+      <p>Drop panels into your story by uploading artwork.</p>
+    `;
+    return placeholder;
+  }
+
   function updateImages(list, pages = null) {
     // If no pages provided, use current DOM state
     const currentPages = pages || getCurrentPageState();
@@ -693,6 +708,7 @@ window.addEventListener("DOMContentLoaded", () => {
     // Clear image list
     imageList.innerHTML = "";
 
+    let appended = 0;
     list.forEach((name) => {
       if (!assigned.has(name)) {
         const wrapper = document.createElement("div");
@@ -707,10 +723,8 @@ window.addEventListener("DOMContentLoaded", () => {
         const delBtn = document.createElement("button");
         delBtn.type = "button";
         delBtn.className = "delete-image-btn";
-        delBtn.textContent = "🗑";
-        delBtn.title = "Delete Image";
-        delBtn.style.marginTop = "4px";
-        delBtn.style.display = "block";
+        delBtn.innerHTML = '<span aria-hidden="true">✕</span> Remove';
+        delBtn.setAttribute("aria-label", "Delete image");
         delBtn.addEventListener("click", () => {
           fetch("/delete-image", {
             method: "POST",
@@ -720,13 +734,21 @@ window.addEventListener("DOMContentLoaded", () => {
             .then((r) => r.json())
             .then(() => {
               wrapper.remove();
+              if (!imageList.querySelector(".image-wrapper")) {
+                imageList.appendChild(createImagePlaceholder());
+              }
             });
         });
         wrapper.appendChild(img);
         wrapper.appendChild(delBtn);
         imageList.appendChild(wrapper);
+        appended += 1;
       }
     });
+
+    if (appended === 0) {
+      imageList.appendChild(createImagePlaceholder());
+    }
   }
 
   // Helper function to get current page state from DOM


### PR DESCRIPTION
## Summary
- rebuild the landing layout with a header, asset library sidebar, and focused workspace featuring quick shortcut hints
- refresh the global styling with a glassmorphism-inspired theme, updated typography, responsive cards, and polished control states
- update builder scripts to generate the new control structure, improve delete buttons, and show an empty-state placeholder for the library
- document the new UI experience and shortcuts in the README and changelog

## Testing
- php -l app/Views/index.php
- composer validate

------
https://chatgpt.com/codex/tasks/task_e_68d46e1f01e0832ab8a8dcb77ab8477a