### PR TITLE
Adjust page grid responsiveness

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Rebuilt the entire interface with a modern glassmorphism aesthetic, refreshed typography, and responsive layout cards to separate the asset library from the page builder.
 - Widened the app shell and workspace grid to give the builder canvas more horizontal breathing room on large screens while keeping the layout responsive.
 - Centered the shell at 90% width and standardized the page cards to two per row for a more intentional workspace rhythm on desktop screens.
+- Updated the workspace page grid to use one column below 1024px, two columns up to 1980px, and three columns on ultra-wide displays while preserving panel alignment and aspect ratios.
 
 ### Fixed
 - Preserve diagonal panel shapes in exported images and PDFs by parsing each layout's CSS rules, caching vendor-prefixed clip-paths, and reapplying them after html2canvas renders the page.

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Uploaded images are stored in `public/uploads/`. Generated exports live in `publ
 
 The refreshed UI introduces a glassmorphism-inspired surface layered over a deep gradient backdrop. Responsive cards separate the asset library from the workspace, while updated typography and spacing improve readability across screen sizes. Buttons and controls now share a consistent accent color palette, and empty states provide clear guidance for first-time users.
 
-The latest pass sets the application shell to a centered 90% width and locks the workspace grid to two page cards per row so the live canvas feels balanced while still collapsing gracefully on smaller screens.
+The latest pass sets the application shell to a centered 90% width and now adapts the workspace grid to one page per row under 1024px, two pages through 1980px, and three pages on ultra-wide displays so the live canvas stays balanced without disrupting panel alignment at any size.
 
 ## Notes
 

--- a/public/css/style.css
+++ b/public/css/style.css
@@ -357,13 +357,19 @@ button.ghost:focus {
 #pages {
     display: grid;
     gap: 24px;
-    grid-template-columns: repeat(2, minmax(0, 1fr));
+    grid-template-columns: 1fr;
     align-content: flex-start;
 }
 
-@media (max-width: 960px) {
+@media (min-width: 1024px) {
     #pages {
-        grid-template-columns: 1fr;
+        grid-template-columns: repeat(2, minmax(0, 1fr));
+    }
+}
+
+@media (min-width: 1980px) {
+    #pages {
+        grid-template-columns: repeat(3, minmax(0, 1fr));
     }
 }
 


### PR DESCRIPTION
## Summary
- adjust the workspace page grid to display one column below 1024px, two columns through 1980px, and three columns on wider screens
- document the updated responsiveness in the README and changelog

## Testing
- composer validate

------
https://chatgpt.com/codex/tasks/task_e_68d4b2b5818c832a90876e82b89f7a4b