### PR TITLE
Fix PDF export constants and restore state on load

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,3 +11,5 @@
 - Preserve diagonal panel shapes in exported images and PDFs by parsing each layout's CSS rules, caching vendor-prefixed clip-paths, and reapplying them after html2canvas renders the page.
 - Keep exported PDF spreads true to their original proportions so two-up pages are no longer subtly squeezed horizontally on each sheet.
 - Restore the classic 5.5" × 8.5" workspace aspect ratio so on-screen previews and exported files fill vertically without trimming the bottom or right-hand panels.
+- Eliminate duplicate PDF export constants that triggered a `pageWidth` redeclaration error in the browser console.
+- Reload saved spreads directly from the persisted state file so previously authored pages render immediately after refresh.

--- a/README.md
+++ b/README.md
@@ -45,3 +45,5 @@ The latest pass sets the application shell to a centered 90% width and now adapt
 * Exported PDFs and PNGs now reliably keep the diagonal panel edges found in the angled layouts. The exporter reads the layout-specific CSS rules to cache each panel's clip-path (including vendor-prefixed values) and reapplies the geometry after html2canvas renders the page so the gutters stay crisp in the output files.
 * PDF exports respect the natural aspect ratio of each canvas when placing two pages per sheet, preventing the subtle horizontal squeeze that previously appeared in the generated documents.
 * Workspace page previews once again adhere to the original 5.5" × 8.5" canvas ratio so panels fill the vertical space and no longer clip along the outer edges in live view or exported assets.
+* Saved layouts are fetched from the server on start-up, so refreshing the browser immediately restores your most recent state from `public/storage/state.json`.
+* Shared PDF page constants prevent duplicate variable declarations, silencing the `pageWidth` console error during exports.


### PR DESCRIPTION
## Summary
- prevent duplicate PDF export constants from redeclaring `pageWidth` during export
- load saved layouts by fetching the persisted state and rebuilding the workspace on startup
- document the fixes in the changelog and README

## Testing
- composer validate

------
https://chatgpt.com/codex/tasks/task_e_68d4ba632338832aae6cadc9af426a33