### PR TITLE
Release session lock for live updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 - Streamlined the page toolbar so the layout selector, gutter picker, and removal action share a single aligned row with matching control dimensions.
 
 ### Fixed
+- Release the PHP session lock before streaming live updates so refreshing the workspace no longer hangs behind an open EventSource connection.
 - Strip library thumbnail styling from dropped artwork so newly placed panels render at full size without waiting for a page refresh.
 - Preserve diagonal panel shapes in exported images and PDFs by parsing each layout's CSS rules, caching vendor-prefixed clip-paths, and reapplying them after html2canvas renders the page.
 - Keep exported PDF spreads true to their original proportions so two-up pages are no longer subtly squeezed horizontally on each sheet.

--- a/README.md
+++ b/README.md
@@ -51,3 +51,4 @@ The latest pass sets the application shell to a centered 90% width and now adapt
 * Shared PDF page constants prevent duplicate variable declarations, silencing the `pageWidth` console error during exports.
 * Layout, gutter, and removal controls now share a single, aligned row with matched sizing so page actions remain balanced and easy to target.
 * Drag-and-dropped artwork now immediately sheds the square thumbnail styling, letting panels render at full size without a manual refresh.
+* Refreshing the workspace no longer stalls because the live update stream releases its PHP session lock before waiting for changes.

--- a/app/Controllers/PageController.php
+++ b/app/Controllers/PageController.php
@@ -50,6 +50,8 @@ class PageController
 
     public function stream(): void
     {
+        $this->releaseSessionLock();
+
         ignore_user_abort(true);
         set_time_limit(0);
 
@@ -77,6 +79,13 @@ class PageController
                 break;
             }
             sleep(1);
+        }
+    }
+
+    private function releaseSessionLock(): void
+    {
+        if (session_status() === PHP_SESSION_ACTIVE) {
+            session_write_close();
         }
     }
 

--- a/tests/SessionLockTest.php
+++ b/tests/SessionLockTest.php
@@ -1,0 +1,36 @@
+<?php
+
+require __DIR__ . '/../vendor/autoload.php';
+
+use App\Controllers\PageController;
+
+session_start();
+$_SESSION['dummy'] = 'value';
+
+$controller = new PageController();
+
+$reflection = new ReflectionClass(PageController::class);
+$method = $reflection->getMethod('releaseSessionLock');
+$method->setAccessible(true);
+
+$statusBefore = session_status();
+
+$method->invoke($controller);
+
+$statusAfter = session_status();
+
+if (session_status() === PHP_SESSION_ACTIVE) {
+    session_destroy();
+}
+
+if ($statusBefore !== PHP_SESSION_ACTIVE) {
+    fwrite(STDERR, "Expected session to be active before releasing the lock.\n");
+    exit(1);
+}
+
+if ($statusAfter !== PHP_SESSION_NONE) {
+    fwrite(STDERR, "Expected session lock to be released after invoking releaseSessionLock().\n");
+    exit(1);
+}
+
+echo "Session lock released successfully.\n";


### PR DESCRIPTION
## Summary
- release the PHP session lock before starting the long-running event stream so refreshes and other requests are not blocked
- document the fix in the README and changelog
- add a regression test that verifies the controller frees the session lock

## Testing
- php -l app/Controllers/PageController.php
- php tests/SessionLockTest.php

------
https://chatgpt.com/codex/tasks/task_e_68d4ecfd025c832ab0064e8a3dbba467