### PR TITLE
Render layout templates server-side

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 - Streamlined the page toolbar so the layout selector, gutter picker, and removal action share a single aligned row with matching control dimensions.
 
 ### Fixed
+- Execute layout PHP templates on the server before sending them to the browser so angled panels regain their SVG masks and render correctly in both the editor and exports.
 - Release the PHP session lock before streaming live updates so refreshing the workspace no longer hangs behind an open EventSource connection.
 - Strip library thumbnail styling from dropped artwork so newly placed panels render at full size without waiting for a page refresh.
 - Preserve diagonal panel shapes in exported images and PDFs by replaying each panel's stored polygon geometry after html2canvas renders the page.

--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ The latest pass sets the application shell to a centered 90% width and now adapt
 ## Notes
 
 * Exported PDFs and PNGs now keep the diagonal panel edges found in the angled layouts by wrapping those panels in inline SVG clip masks. The browser and html2canvas both honor the embedded geometry, and the exporter still replays each polygon so the gutters stay crisp in the final files.
+* Layout templates are rendered through PHP on the server before they reach the browser so angled masks and data attributes are present during initial paint and export capture.
 * PDF exports respect the natural aspect ratio of each captured canvas when placing two pages per sheet, preventing the subtle horizontal squeeze and the top-and-bottom letterboxing that previously appeared in the generated documents.
 * Workspace page previews are locked to a 1:1.545 aspect ratio that mirrors a single page column while rendering flush to the canvas frame, eliminating the rounded border padding and keeping the live view aligned with exported spreads.
 * Saved layouts are loaded exclusively from `public/storage/state.json` at start-up, ensuring the browser always reflects the latest persisted state.

--- a/app/Models/ComicModel.php
+++ b/app/Models/ComicModel.php
@@ -115,9 +115,24 @@ class ComicModel
     {
         $templates = [];
         foreach ($this->getLayouts() as $name => $file) {
-            $templates[$name] = file_get_contents($file);
+            $templates[$name] = $this->renderLayoutTemplate($file);
         }
         return $templates;
+    }
+
+    private function renderLayoutTemplate(string $file): string
+    {
+        if (!is_file($file)) {
+            return '';
+        }
+
+        $renderer = static function (string $__file__) {
+            ob_start();
+            include $__file__;
+            return (string)ob_get_clean();
+        };
+
+        return $renderer($file);
     }
 
     public function getLayoutStyles(): array

--- a/tests/ComicModelTemplateRenderingTest.php
+++ b/tests/ComicModelTemplateRenderingTest.php
@@ -1,0 +1,33 @@
+<?php
+require __DIR__ . '/../vendor/autoload.php';
+
+use App\Models\ComicModel;
+
+$model = new ComicModel();
+$templates = $model->getLayoutTemplates();
+
+if (!$templates) {
+    fwrite(STDERR, "ComicModel::getLayoutTemplates returned no templates." . PHP_EOL);
+    exit(1);
+}
+
+foreach ($templates as $name => $markup) {
+    $trimmed = trim($markup);
+
+    if ($trimmed === '') {
+        fwrite(STDERR, sprintf('Template "%s" rendered empty markup.%s', $name, PHP_EOL));
+        exit(1);
+    }
+
+    if (str_contains($trimmed, '<?php')) {
+        fwrite(STDERR, sprintf('Template "%s" still contains PHP tags after rendering.%s', $name, PHP_EOL));
+        exit(1);
+    }
+
+    if (str_ends_with($trimmed, '</div>') === false) {
+        fwrite(STDERR, sprintf('Template "%s" markup may be incomplete or malformed.%s', $name, PHP_EOL));
+        exit(1);
+    }
+}
+
+echo "ComicModel rendered layout templates successfully." . PHP_EOL;


### PR DESCRIPTION
## Summary
- render layout PHP templates before sending them to the browser so angled panels keep their masks
- add a regression test that ensures ComicModel returns fully rendered markup for every layout
- document the server-side rendering change in the README and changelog

## Testing
- php -l app/Models/ComicModel.php
- php -l tests/ComicModelTemplateRenderingTest.php
- php tests/LayoutTemplateTest.php
- php tests/SessionLockTest.php
- php tests/ComicModelTemplateRenderingTest.php

------
https://chatgpt.com/codex/tasks/task_e_68d50ea65254832a920d038a1d909898