### PR TITLE
Fix SVG polygon points for angled layouts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 - Streamlined the page toolbar so the layout selector, gutter picker, and removal action share a single aligned row with matching control dimensions.
 
 ### Fixed
+- Replace percentage-based polygon coordinates inside inline SVG masks with unitless values so browsers stop emitting console errors while angled layouts render correctly.
 - Execute layout PHP templates on the server before sending them to the browser so angled panels regain their SVG masks and render correctly in both the editor and exports.
 - Release the PHP session lock before streaming live updates so refreshing the workspace no longer hangs behind an open EventSource connection.
 - Strip library thumbnail styling from dropped artwork so newly placed panels render at full size without waiting for a page refresh.

--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ The latest pass sets the application shell to a centered 90% width and now adapt
 ## Notes
 
 * Exported PDFs and PNGs now keep the diagonal panel edges found in the angled layouts by wrapping those panels in inline SVG clip masks. The browser and html2canvas both honor the embedded geometry, and the exporter still replays each polygon so the gutters stay crisp in the final files.
+* Inline SVG masks now declare their polygon geometry with unitless coordinates, preventing browsers from logging console errors about invalid `%` values while preserving the diagonal panel shapes.
 * Layout templates are rendered through PHP on the server before they reach the browser so angled masks and data attributes are present during initial paint and export capture.
 * PDF exports respect the natural aspect ratio of each captured canvas when placing two pages per sheet, preventing the subtle horizontal squeeze and the top-and-bottom letterboxing that previously appeared in the generated documents.
 * Workspace page previews are locked to a 1:1.545 aspect ratio that mirrors a single page column while rendering flush to the canvas frame, eliminating the rounded border padding and keeping the live view aligned with exported spreads.

--- a/layouts/one-horizontal-top-two-vertical-angled-bottom.php
+++ b/layouts/one-horizontal-top-two-vertical-angled-bottom.php
@@ -10,7 +10,7 @@ $panel3Clip = uniqid('one-horizontal-top-two-vertical-angled-bottom-panel3-');
         <svg class="panel-mask" viewBox="0 0 100 100" preserveAspectRatio="none" aria-hidden="true">
             <defs>
                 <clipPath id="<?= htmlspecialchars($panel2Clip, ENT_QUOTES, 'UTF-8') ?>">
-                    <polygon points="0% 0%, 100% 0%, 94% 100%, 0% 100%"></polygon>
+                    <polygon points="0 0, 100 0, 94 100, 0 100"></polygon>
                 </clipPath>
             </defs>
             <foreignObject x="0" y="0" width="100" height="100" clip-path="url(#<?= htmlspecialchars($panel2Clip, ENT_QUOTES, 'UTF-8') ?>)">
@@ -22,7 +22,7 @@ $panel3Clip = uniqid('one-horizontal-top-two-vertical-angled-bottom-panel3-');
         <svg class="panel-mask" viewBox="0 0 100 100" preserveAspectRatio="none" aria-hidden="true">
             <defs>
                 <clipPath id="<?= htmlspecialchars($panel3Clip, ENT_QUOTES, 'UTF-8') ?>">
-                    <polygon points="6% 0%, 100% 0%, 100% 100%, 0% 100%"></polygon>
+                    <polygon points="6 0, 100 0, 100 100, 0 100"></polygon>
                 </clipPath>
             </defs>
             <foreignObject x="0" y="0" width="100" height="100" clip-path="url(#<?= htmlspecialchars($panel3Clip, ENT_QUOTES, 'UTF-8') ?>)">

--- a/layouts/three-horizontal-angled.php
+++ b/layouts/three-horizontal-angled.php
@@ -8,7 +8,7 @@ $panel3Clip = uniqid('three-horizontal-angled-panel3-');
         <svg class="panel-mask" viewBox="0 0 100 100" preserveAspectRatio="none" aria-hidden="true">
             <defs>
                 <clipPath id="<?= htmlspecialchars($panel1Clip, ENT_QUOTES, 'UTF-8') ?>">
-                    <polygon points="0% 0%, 100% 0%, 100% 97%, 0% 100%"></polygon>
+                    <polygon points="0 0, 100 0, 100 97, 0 100"></polygon>
                 </clipPath>
             </defs>
             <foreignObject x="0" y="0" width="100" height="100" clip-path="url(#<?= htmlspecialchars($panel1Clip, ENT_QUOTES, 'UTF-8') ?>)">
@@ -20,7 +20,7 @@ $panel3Clip = uniqid('three-horizontal-angled-panel3-');
         <svg class="panel-mask" viewBox="0 0 100 100" preserveAspectRatio="none" aria-hidden="true">
             <defs>
                 <clipPath id="<?= htmlspecialchars($panel2Clip, ENT_QUOTES, 'UTF-8') ?>">
-                    <polygon points="0% 3%, 100% 0%, 100% 97%, 0% 100%"></polygon>
+                    <polygon points="0 3, 100 0, 100 97, 0 100"></polygon>
                 </clipPath>
             </defs>
             <foreignObject x="0" y="0" width="100" height="100" clip-path="url(#<?= htmlspecialchars($panel2Clip, ENT_QUOTES, 'UTF-8') ?>)">
@@ -32,7 +32,7 @@ $panel3Clip = uniqid('three-horizontal-angled-panel3-');
         <svg class="panel-mask" viewBox="0 0 100 100" preserveAspectRatio="none" aria-hidden="true">
             <defs>
                 <clipPath id="<?= htmlspecialchars($panel3Clip, ENT_QUOTES, 'UTF-8') ?>">
-                    <polygon points="0% 3%, 100% 0%, 100% 100%, 0% 100%"></polygon>
+                    <polygon points="0 3, 100 0, 100 100, 0 100"></polygon>
                 </clipPath>
             </defs>
             <foreignObject x="0" y="0" width="100" height="100" clip-path="url(#<?= htmlspecialchars($panel3Clip, ENT_QUOTES, 'UTF-8') ?>)">

--- a/layouts/three-vertical-angled.php
+++ b/layouts/three-vertical-angled.php
@@ -8,7 +8,7 @@ $panel3Clip = uniqid('three-vertical-angled-panel3-');
         <svg class="panel-mask" viewBox="0 0 100 100" preserveAspectRatio="none" aria-hidden="true">
             <defs>
                 <clipPath id="<?= htmlspecialchars($panel1Clip, ENT_QUOTES, 'UTF-8') ?>">
-                    <polygon points="0% 0%, 100% 0%, 94% 100%, 0% 100%"></polygon>
+                    <polygon points="0 0, 100 0, 94 100, 0 100"></polygon>
                 </clipPath>
             </defs>
             <foreignObject x="0" y="0" width="100" height="100" clip-path="url(#<?= htmlspecialchars($panel1Clip, ENT_QUOTES, 'UTF-8') ?>)">
@@ -20,7 +20,7 @@ $panel3Clip = uniqid('three-vertical-angled-panel3-');
         <svg class="panel-mask" viewBox="0 0 100 100" preserveAspectRatio="none" aria-hidden="true">
             <defs>
                 <clipPath id="<?= htmlspecialchars($panel2Clip, ENT_QUOTES, 'UTF-8') ?>">
-                    <polygon points="6% 0%, 100% 0%, 94% 100%, 0% 100%"></polygon>
+                    <polygon points="6 0, 100 0, 94 100, 0 100"></polygon>
                 </clipPath>
             </defs>
             <foreignObject x="0" y="0" width="100" height="100" clip-path="url(#<?= htmlspecialchars($panel2Clip, ENT_QUOTES, 'UTF-8') ?>)">
@@ -32,7 +32,7 @@ $panel3Clip = uniqid('three-vertical-angled-panel3-');
         <svg class="panel-mask" viewBox="0 0 100 100" preserveAspectRatio="none" aria-hidden="true">
             <defs>
                 <clipPath id="<?= htmlspecialchars($panel3Clip, ENT_QUOTES, 'UTF-8') ?>">
-                    <polygon points="6% 0%, 100% 0%, 100% 100%, 0% 100%"></polygon>
+                    <polygon points="6 0, 100 0, 100 100, 0 100"></polygon>
                 </clipPath>
             </defs>
             <foreignObject x="0" y="0" width="100" height="100" clip-path="url(#<?= htmlspecialchars($panel3Clip, ENT_QUOTES, 'UTF-8') ?>)">

--- a/layouts/two-horizontal-angled.php
+++ b/layouts/two-horizontal-angled.php
@@ -7,7 +7,7 @@ $panel2Clip = uniqid('two-horizontal-angled-panel2-');
         <svg class="panel-mask" viewBox="0 0 100 100" preserveAspectRatio="none" aria-hidden="true">
             <defs>
                 <clipPath id="<?= htmlspecialchars($panel1Clip, ENT_QUOTES, 'UTF-8') ?>">
-                    <polygon points="0% 0%, 100% 0%, 100% 97%, 0% 100%"></polygon>
+                    <polygon points="0 0, 100 0, 100 97, 0 100"></polygon>
                 </clipPath>
             </defs>
             <foreignObject x="0" y="0" width="100" height="100" clip-path="url(#<?= htmlspecialchars($panel1Clip, ENT_QUOTES, 'UTF-8') ?>)">
@@ -19,7 +19,7 @@ $panel2Clip = uniqid('two-horizontal-angled-panel2-');
         <svg class="panel-mask" viewBox="0 0 100 100" preserveAspectRatio="none" aria-hidden="true">
             <defs>
                 <clipPath id="<?= htmlspecialchars($panel2Clip, ENT_QUOTES, 'UTF-8') ?>">
-                    <polygon points="0% 3%, 100% 0%, 100% 100%, 0% 100%"></polygon>
+                    <polygon points="0 3, 100 0, 100 100, 0 100"></polygon>
                 </clipPath>
             </defs>
             <foreignObject x="0" y="0" width="100" height="100" clip-path="url(#<?= htmlspecialchars($panel2Clip, ENT_QUOTES, 'UTF-8') ?>)">

--- a/layouts/two-vertical-angled-top-one-horizontal-bottom.php
+++ b/layouts/two-vertical-angled-top-one-horizontal-bottom.php
@@ -7,7 +7,7 @@ $panel2Clip = uniqid('two-vertical-angled-top-one-horizontal-bottom-panel2-');
         <svg class="panel-mask" viewBox="0 0 100 100" preserveAspectRatio="none" aria-hidden="true">
             <defs>
                 <clipPath id="<?= htmlspecialchars($panel1Clip, ENT_QUOTES, 'UTF-8') ?>">
-                    <polygon points="0% 0%, 100% 0%, 94% 100%, 0% 100%"></polygon>
+                    <polygon points="0 0, 100 0, 94 100, 0 100"></polygon>
                 </clipPath>
             </defs>
             <foreignObject x="0" y="0" width="100" height="100" clip-path="url(#<?= htmlspecialchars($panel1Clip, ENT_QUOTES, 'UTF-8') ?>)">
@@ -19,7 +19,7 @@ $panel2Clip = uniqid('two-vertical-angled-top-one-horizontal-bottom-panel2-');
         <svg class="panel-mask" viewBox="0 0 100 100" preserveAspectRatio="none" aria-hidden="true">
             <defs>
                 <clipPath id="<?= htmlspecialchars($panel2Clip, ENT_QUOTES, 'UTF-8') ?>">
-                    <polygon points="6% 0%, 100% 0%, 100% 100%, 0% 100%"></polygon>
+                    <polygon points="6 0, 100 0, 100 100, 0 100"></polygon>
                 </clipPath>
             </defs>
             <foreignObject x="0" y="0" width="100" height="100" clip-path="url(#<?= htmlspecialchars($panel2Clip, ENT_QUOTES, 'UTF-8') ?>)">


### PR DESCRIPTION
## Summary
- replace percentage-based SVG polygon point coordinates in angled layouts with unitless values so inline masks parse cleanly in all browsers
- document the change in the changelog and README notes for clarity

## Testing
- php -l layouts/two-horizontal-angled.php
- php -l layouts/one-horizontal-top-two-vertical-angled-bottom.php
- php -l layouts/two-vertical-angled-top-one-horizontal-bottom.php
- php -l layouts/three-horizontal-angled.php
- php -l layouts/three-vertical-angled.php
- php tests/LayoutTemplateTest.php

------
https://chatgpt.com/codex/tasks/task_e_68d51085ffb0832abb5d70708a8bb1f1