### PR TITLE
Remove angled frame code and fix rectangular exports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,14 +11,13 @@
 - Updated the workspace page grid to use one column below 1024px, two columns up to 1980px, and three columns on ultra-wide displays while preserving panel alignment and aspect ratios.
 - Locked the layout preview container to a 1:1.545 aspect ratio that matches a single page column and removed its rounded border so spreads sit flush without white bands.
 - Streamlined the page toolbar so the layout selector, gutter picker, and removal action share a single aligned row with matching control dimensions.
+- Removed the remaining angled panel styling and export helpers so every layout now uses straightforward rectangular frames.
 
 ### Fixed
-- Replace percentage-based polygon coordinates inside inline SVG masks with unitless values so browsers stop emitting console errors while angled layouts render correctly.
-- Execute layout PHP templates on the server before sending them to the browser so angled panels regain their SVG masks and render correctly in both the editor and exports.
+- Execute layout PHP templates on the server before sending them to the browser so panels render correctly in both the editor and exports.
 - Release the PHP session lock before streaming live updates so refreshing the workspace no longer hangs behind an open EventSource connection.
 - Strip library thumbnail styling from dropped artwork so newly placed panels render at full size without waiting for a page refresh.
-- Preserve diagonal panel shapes in exported images and PDFs by replaying each panel's stored polygon geometry after html2canvas renders the page.
-- Replace CSS clip-paths in angled layouts with inline SVG masks and dedicated panel content containers so diagonal gutters render correctly in the browser and survive PDF/image exports.
+- Restore clean rectangular panel exports by relying on the direct html2canvas capture instead of replaying clip-path data after render.
 - Keep exported PDF spreads true to their original proportions so two-up pages are no longer subtly squeezed horizontally on each sheet.
 - Scale each exported layout using its captured aspect ratio so generated PDFs no longer include white bands above or below the artwork.
 - Restore the classic 5.5" × 8.5" workspace aspect ratio so on-screen previews and exported files fill vertically without trimming the bottom or right-hand panels.

--- a/README.md
+++ b/README.md
@@ -43,9 +43,8 @@ The latest pass sets the application shell to a centered 90% width and now adapt
 
 ## Notes
 
-* Exported PDFs and PNGs now keep the diagonal panel edges found in the angled layouts by wrapping those panels in inline SVG clip masks. The browser and html2canvas both honor the embedded geometry, and the exporter still replays each polygon so the gutters stay crisp in the final files.
-* Inline SVG masks now declare their polygon geometry with unitless coordinates, preventing browsers from logging console errors about invalid `%` values while preserving the diagonal panel shapes.
-* Layout templates are rendered through PHP on the server before they reach the browser so angled masks and data attributes are present during initial paint and export capture.
+* Exported PDFs and PNGs now rely on the html2canvas capture directly, eliminating the stretched and clipped rectangles that appeared after the angled panel cleanup.
+* Layout templates are rendered through PHP on the server before they reach the browser so every panel container is present during initial paint and export capture.
 * PDF exports respect the natural aspect ratio of each captured canvas when placing two pages per sheet, preventing the subtle horizontal squeeze and the top-and-bottom letterboxing that previously appeared in the generated documents.
 * Workspace page previews are locked to a 1:1.545 aspect ratio that mirrors a single page column while rendering flush to the canvas frame, eliminating the rounded border padding and keeping the live view aligned with exported spreads.
 * Saved layouts are loaded exclusively from `public/storage/state.json` at start-up, ensuring the browser always reflects the latest persisted state.

--- a/layouts/cover.css
+++ b/layouts/cover.css
@@ -4,5 +4,4 @@
     left: 12px;
     width: calc(100% - 24px);
     height: calc(100% - 24px);
-    clip-path: polygon(0 0, 100% 0, 100% 100%, 0 100%);
 }

--- a/layouts/four-grid.css
+++ b/layouts/four-grid.css
@@ -3,7 +3,6 @@
     left: 12px;
     width: calc(50% - 18px);
     height: calc(50% - 18px);
-    clip-path: polygon(0 0, 100% 0, 100% 100%, 0 100%);
 }
 
 .layout.four-grid .panel2 {
@@ -11,7 +10,6 @@
     left: calc(50% + 6px);
     width: calc(50% - 18px);
     height: calc(50% - 18px);
-    clip-path: polygon(0 0, 100% 0, 100% 100%, 0 100%);
 }
 
 .layout.four-grid .panel3 {
@@ -19,7 +17,6 @@
     left: 12px;
     width: calc(50% - 18px);
     height: calc(50% - 18px);
-    clip-path: polygon(0 0, 100% 0, 100% 100%, 0 100%);
 }
 
 .layout.four-grid .panel4 {
@@ -27,5 +24,4 @@
     left: calc(50% + 6px);
     width: calc(50% - 18px);
     height: calc(50% - 18px);
-    clip-path: polygon(0 0, 100% 0, 100% 100%, 0 100%);
 }

--- a/layouts/one-horizontal-top-three-vertical-bottom.css
+++ b/layouts/one-horizontal-top-three-vertical-bottom.css
@@ -4,7 +4,6 @@
     left: 12px;
     width: calc(100% - 24px);
     height: calc(50% - 18px);
-    clip-path: polygon(0 0, 100% 0, 100% 100%, 0 100%);
 }
 /* Bottom left panel with equal gutter */
 /* Bottom left panel with equal gutter */
@@ -13,7 +12,6 @@
     left: 12px;
     width: calc(33.333% - 16px);
     height: calc(50% - 18px);
-    clip-path: polygon(0 0, 100% 0, 100% 100%, 0 100%);
 }
 /* Bottom center panel with equal gutter */
 /* Bottom center panel with equal gutter */
@@ -22,7 +20,6 @@
     left: calc(33.333% + 12px);
     width: calc(33.333% - 16px);
     height: calc(50% - 18px);
-    clip-path: polygon(0 0, 100% 0, 100% 100%, 0 100%);
 }
 /* Bottom right panel with equal gutter */
 /* Bottom right panel with equal gutter */
@@ -33,5 +30,4 @@
     left: calc(66.666% + 12px);
     width: calc(33.333% - 24px);
     height: calc(50% - 18px);
-    clip-path: polygon(0 0, 100% 0, 100% 100%, 0 100%);
 }

--- a/layouts/one-horizontal-top-two-vertical-bottom.css
+++ b/layouts/one-horizontal-top-two-vertical-bottom.css
@@ -4,19 +4,16 @@
     left: 12px;
     width: calc(100% - 24px);
     height: calc(50% - 18px);
-    clip-path: polygon(0 0, 100% 0, 100% 100%, 0 100%);
 }
 .layout.one-horizontal-top-two-vertical-bottom .panel2 {
     top: calc(50% + 6px);
     left: 12px;
     width: calc(50% - 18px);
     height: calc(50% - 18px);
-    clip-path: polygon(0 0, 100% 0, 100% 100%, 0 100%);
 }
 .layout.one-horizontal-top-two-vertical-bottom .panel3 {
     top: calc(50% + 6px);
     left: calc(50% + 6px);
     width: calc(50% - 18px);
     height: calc(50% - 18px);
-    clip-path: polygon(0 0, 100% 0, 100% 100%, 0 100%);
 }

--- a/layouts/one-vertical-left-two-horizontal-right.css
+++ b/layouts/one-vertical-left-two-horizontal-right.css
@@ -4,19 +4,16 @@
     top: 12px;
     width: calc(50% - 18px);
     height: calc(100% - 24px);
-    clip-path: polygon(0 0, 100% 0, 100% 100%, 0 100%);
 }
 .layout.one-vertical-left-two-horizontal-right .panel2 {
     top: 12px;
     left: calc(50% + 6px);
     width: calc(50% - 18px);
     height: calc(50% - 18px);
-    clip-path: polygon(0 0, 100% 0, 100% 100%, 0 100%);
 }
 .layout.one-vertical-left-two-horizontal-right .panel3 {
     top: calc(50% + 6px);
     left: calc(50% + 6px);
     width: calc(50% - 18px);
     height: calc(50% - 18px);
-    clip-path: polygon(0 0, 100% 0, 100% 100%, 0 100%);
 }

--- a/layouts/three-horizontal.css
+++ b/layouts/three-horizontal.css
@@ -4,19 +4,16 @@
     left: 12px;
     width: calc(100% - 24px);
     height: calc(33.333% - 18px);
-    clip-path: polygon(0 0, 100% 0, 100% 100%, 0 100%);
 }
 .layout.three-horizontal .panel2 {
     top: calc(33.333% + 6px);
     left: 12px;
     width: calc(100% - 24px);
     height: calc(33.333% - 18px);
-    clip-path: polygon(0 0, 100% 0, 100% 100%, 0 100%);
 }
 .layout.three-horizontal .panel3 {
     top: calc(66.666% + 6px);
     left: 12px;
     width: calc(100% - 24px);
     height: calc(33.333% - 18px);
-    clip-path: polygon(0 0, 100% 0, 100% 100%, 0 100%);
 }

--- a/layouts/three-vertical.css
+++ b/layouts/three-vertical.css
@@ -4,19 +4,16 @@
     left: 12px;
     width: calc(33.333% - 16px);
     height: calc(100% - 24px);
-    clip-path: polygon(0 0, 100% 0, 100% 100%, 0 100%);
 }
 .layout.three-vertical .panel2 {
     top: 12px;
     left: calc(33.333% + 8px);
     width: calc(33.333% - 16px);
     height: calc(100% - 24px);
-    clip-path: polygon(0 0, 100% 0, 100% 100%, 0 100%);
 }
 .layout.three-vertical .panel3 {
     top: 12px;
     left: calc(66.666% + 4px);
     width: calc(33.333% - 16px);
     height: calc(100% - 24px);
-    clip-path: polygon(0 0, 100% 0, 100% 100%, 0 100%);
 }

--- a/layouts/two-horizontal-left-one-vertical-right.css
+++ b/layouts/two-horizontal-left-one-vertical-right.css
@@ -4,19 +4,16 @@
     left: 12px;
     width: calc(50% - 18px);
     height: calc(50% - 18px);
-    clip-path: polygon(0 0, 100% 0, 100% 100%, 0 100%);
 }
 .layout.two-horizontal-left-one-vertical-right .panel2 {
     top: calc(50% + 6px);
     left: 12px;
     width: calc(50% - 18px);
     height: calc(50% - 18px);
-    clip-path: polygon(0 0, 100% 0, 100% 100%, 0 100%);
 }
 .layout.two-horizontal-left-one-vertical-right .panel3 {
     top: 12px;
     left: calc(50% + 6px);
     width: calc(50% - 18px);
     height: calc(100% - 24px);
-    clip-path: polygon(0 0, 100% 0, 100% 100%, 0 100%);
 }

--- a/layouts/two-horizontal.css
+++ b/layouts/two-horizontal.css
@@ -6,12 +6,10 @@
     left: 12px;
     width: calc(100% - 24px);
     height: calc(50% - 18px);
-    clip-path: polygon(0 0, 100% 0, 100% 100%, 0 100%);
 }
 .layout.two-horizontal .panel2 {
     top: calc(50% + 6px);
     left: 12px;
     width: calc(100% - 24px);
     height: calc(50% - 18px);
-    clip-path: polygon(0 0, 100% 0, 100% 100%, 0 100%);
 }

--- a/layouts/two-vertical-top-one-horizontal-bottom.css
+++ b/layouts/two-vertical-top-one-horizontal-bottom.css
@@ -4,19 +4,16 @@
     left: 12px;
     width: calc(50% - 18px);
     height: calc(50% - 18px);
-    clip-path: polygon(0 0, 100% 0, 100% 100%, 0 100%);
 }
 .layout.two-vertical-top-one-horizontal-bottom .panel2 {
     top: 12px;
     left: calc(50% + 6px);
     width: calc(50% - 18px);
     height: calc(50% - 18px);
-    clip-path: polygon(0 0, 100% 0, 100% 100%, 0 100%);
 }
 .layout.two-vertical-top-one-horizontal-bottom .panel3 {
     top: calc(50% + 6px);
     left: 12px;
     width: calc(100% - 24px);
     height: calc(50% - 18px);
-    clip-path: polygon(0 0, 100% 0, 100% 100%, 0 100%);
 }

--- a/tests/LayoutTemplateTest.php
+++ b/tests/LayoutTemplateTest.php
@@ -42,26 +42,6 @@ foreach ($layoutFiles as $layoutFile) {
             );
         }
 
-        $clipPolygon = trim($panel->getAttribute('data-clip-polygon'));
-        if ($clipPolygon !== '') {
-            if (stripos($clipPolygon, 'polygon(') !== 0) {
-                $failures[] = sprintf(
-                    'Panel with slot "%s" in %s has an invalid data-clip-polygon value: %s',
-                    $panel->getAttribute('data-slot') ?: '(unknown)',
-                    basename($layoutFile),
-                    $clipPolygon
-                );
-            }
-
-            $maskSvg = $xpath->query('.//svg[contains(concat(" ", normalize-space(@class), " "), " panel-mask ")]', $panel);
-            if (!$maskSvg || !$maskSvg->length) {
-                $failures[] = sprintf(
-                    'Panel with slot "%s" in %s declares a clip polygon but has no inline SVG mask.',
-                    $panel->getAttribute('data-slot') ?: '(unknown)',
-                    basename($layoutFile)
-                );
-            }
-        }
     }
 }
 
@@ -72,4 +52,4 @@ if ($failures) {
     exit(1);
 }
 
-echo "All layout templates include panel-inner containers and SVG masks where required." . PHP_EOL;
+echo "All layout templates include panel-inner containers." . PHP_EOL;


### PR DESCRIPTION
## Summary
- strip the remaining clip-path cache and mask reapplication logic from the client so layouts rely on the native html2canvas output
- simplify every layout stylesheet now that only rectangular panels remain
- update the layout template smoke test and docs to reflect the rectangular-only rendering pipeline

## Testing
- php -l tests/LayoutTemplateTest.php
- php tests/LayoutTemplateTest.php
- php tests/ComicModelTemplateRenderingTest.php
- php tests/SessionLockTest.php

------
https://chatgpt.com/codex/tasks/task_e_68d512a0ebbc832ab534da8b5f9211f9