### PR TITLE
Add mobile image modal and touch insertion workflow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [Unreleased]
 ### Added
 - Stream live page updates over Server-Sent Events so any open workspace reacts immediately when `state.json` is modified.
+- Convert the asset library into a full-screen mobile modal triggered by a persistent bottom bar, with double-tap placement for selected images.
 
 ### Changed
 - Rebuilt the entire interface with a modern glassmorphism aesthetic, refreshed typography, and responsive layout cards to separate the asset library from the page builder.

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ A modern MVC PHP application for crafting comic spreads. Upload artwork, drag it
 - **Real-time sync** – The browser listens to server-sent events so every open tab mirrors updates written to `state.json` instantly.
 - **One-click exports** – Generate PDFs or high-quality image sets directly from the browser.
 - **Keyboard shortcuts** – Stay in flow with quick commands for saving, creating pages, and exporting.
+- **Mobile-first asset picker** – A bottom image dock opens a full-screen library so you can select art and drop it into panels with a double tap.
 
 ## Setup
 
@@ -40,6 +41,10 @@ Uploaded images are stored in `public/uploads/`. Generated exports live in `publ
 The refreshed UI introduces a glassmorphism-inspired surface layered over a deep gradient backdrop. Responsive cards separate the asset library from the workspace, while updated typography and spacing improve readability across screen sizes. Buttons and controls now share a consistent accent color palette, and empty states provide clear guidance for first-time users.
 
 The latest pass sets the application shell to a centered 90% width and now adapts the workspace grid to one page per row under 1024px, two pages through 1980px, and three pages on ultra-wide displays so the live canvas stays balanced without disrupting panel alignment at any size.
+
+## Mobile image workflow
+
+On screens 768px wide and below, an **Images** pill anchors to the bottom edge of the interface. Tapping it reveals the asset library as a full-screen modal with upload controls. Select an image to collapse the modal, then double tap any panel to place the artwork instantly—no precision drag-and-drop required on touch devices.
 
 ## Note
 * Exported PDFs and PNGs are rendered with an internal high-resolution canvas pass that mirrors every panel transform and rounded gutter, preventing the ghosted doubles that previously slipped into exported files.

--- a/app/Views/index.php
+++ b/app/Views/index.php
@@ -27,6 +27,10 @@
     </header>
     <main class="app-main">
         <section id="images" aria-label="Image library">
+            <button type="button" id="closeImageModal" class="mobile-modal-close" aria-label="Close image library">
+                <span aria-hidden="true">✕</span>
+                <span class="mobile-modal-close__text">Close</span>
+            </button>
             <div class="card-header">
                 <div>
                     <h2>Asset Library</h2>
@@ -65,6 +69,10 @@
             <div id="pages"></div>
         </section>
     </main>
+    <button id="mobileImageToggle" type="button" class="mobile-image-bar" aria-controls="images" aria-expanded="false">
+        <span class="mobile-image-bar__label">Images</span>
+    </button>
+    <div id="mobileImageBackdrop" class="mobile-image-backdrop" hidden aria-hidden="true"></div>
 </div>
 <script>
 const layouts = <?= json_encode(array_keys($layouts)) ?>;

--- a/public/css/style.css
+++ b/public/css/style.css
@@ -582,3 +582,131 @@ button.ghost:focus {
         grid-template-columns: 1fr;
     }
 }
+
+.image-wrapper.selected {
+    border-color: rgba(99, 102, 241, 0.55);
+    box-shadow: 0 12px 24px -18px rgba(99, 102, 241, 0.65);
+}
+
+.image-wrapper.selected .thumb {
+    box-shadow: 0 12px 24px -16px rgba(99, 102, 241, 0.65);
+}
+
+.mobile-modal-close {
+    display: none;
+    align-items: center;
+    justify-content: center;
+    gap: 8px;
+    align-self: flex-end;
+    background: rgba(15, 23, 42, 0.45);
+    color: var(--text-primary);
+    border: 1px solid rgba(148, 163, 184, 0.25);
+    border-radius: 999px;
+    padding: 8px 14px;
+    font-size: 0.85rem;
+}
+
+.mobile-modal-close:hover,
+.mobile-modal-close:focus {
+    background: rgba(99, 102, 241, 0.18);
+    border-color: rgba(99, 102, 241, 0.45);
+    outline: none;
+}
+
+.mobile-image-bar {
+    display: none;
+    position: fixed;
+    left: 50%;
+    bottom: 24px;
+    transform: translateX(-50%);
+    padding: 14px 28px;
+    border-radius: 999px;
+    background: linear-gradient(135deg, var(--accent), var(--accent-strong));
+    color: white;
+    font-size: 1rem;
+    font-weight: 600;
+    letter-spacing: 0.04em;
+    box-shadow: var(--shadow-focus);
+    z-index: 1200;
+    transition: transform var(--transition), opacity var(--transition);
+}
+
+.mobile-image-backdrop {
+    display: none;
+    position: fixed;
+    inset: 0;
+    background: rgba(2, 6, 23, 0.65);
+    backdrop-filter: blur(14px);
+    z-index: 1100;
+}
+
+body.image-library-open {
+    overflow: hidden;
+}
+
+body.image-library-open .mobile-image-backdrop {
+    display: block;
+}
+
+body.image-library-open .mobile-image-bar {
+    opacity: 0;
+    pointer-events: none;
+    transform: translate(-50%, 140%);
+    transition: opacity var(--transition), transform var(--transition);
+}
+
+@media (max-width: 768px) {
+    .app-shell {
+        padding-bottom: 108px;
+    }
+
+    #images {
+        position: fixed;
+        inset: 0;
+        display: flex;
+        transform: translateY(100%);
+        transition: transform 220ms ease;
+        border-radius: 32px 32px 0 0;
+        max-width: none;
+        width: 100%;
+        height: 100%;
+        overflow-y: auto;
+        z-index: 1150;
+        padding-bottom: 120px;
+        background: rgba(15, 23, 42, 0.82);
+        backdrop-filter: blur(18px);
+    }
+
+    #images.is-open {
+        transform: translateY(0);
+    }
+
+    #images .card-header {
+        padding-top: 12px;
+    }
+
+    #images .mobile-modal-close {
+        display: inline-flex;
+        position: sticky;
+        top: 16px;
+        right: 24px;
+        margin-left: auto;
+        z-index: 1;
+    }
+
+    #imageList {
+        max-height: none;
+    }
+
+    .mobile-image-bar {
+        display: inline-flex;
+    }
+
+    body.image-library-open #images {
+        box-shadow: 0 -32px 60px -32px rgba(2, 6, 23, 0.75);
+    }
+
+    body.image-library-open .mobile-image-bar {
+        display: inline-flex;
+    }
+}

--- a/public/js/app.js
+++ b/public/js/app.js
@@ -1,5 +1,9 @@
 window.addEventListener("DOMContentLoaded", () => {
   const imageList = document.getElementById("imageList");
+  const imagesSection = document.getElementById("images");
+  const mobileImageToggle = document.getElementById("mobileImageToggle");
+  const mobileImageBackdrop = document.getElementById("mobileImageBackdrop");
+  const mobileModalClose = document.getElementById("closeImageModal");
   let pageCounter = 0;
   let saveTimeout = null;
   let isUpdatingFromServer = false;
@@ -11,6 +15,91 @@ window.addEventListener("DOMContentLoaded", () => {
   const PDF_COLUMN_WIDTH = PDF_PAGE_WIDTH / 2;
   const DEFAULT_GUTTER_COLOR = "#cccccc";
   const EXPORT_SCALE = 2;
+  let selectedImageName = null;
+  let selectedImageWrapper = null;
+
+  function isMobileViewport() {
+    return window.matchMedia("(max-width: 768px)").matches;
+  }
+
+  function openImageLibrary() {
+    if (!imagesSection) return;
+    imagesSection.classList.add("is-open");
+    document.body.classList.add("image-library-open");
+    if (mobileImageToggle) {
+      mobileImageToggle.setAttribute("aria-expanded", "true");
+    }
+    if (mobileImageBackdrop) {
+      mobileImageBackdrop.hidden = false;
+    }
+  }
+
+  function closeImageLibrary() {
+    if (!imagesSection) return;
+    imagesSection.classList.remove("is-open");
+    document.body.classList.remove("image-library-open");
+    if (mobileImageToggle) {
+      mobileImageToggle.setAttribute("aria-expanded", "false");
+    }
+    if (mobileImageBackdrop) {
+      mobileImageBackdrop.hidden = true;
+    }
+  }
+
+  function clearSelectedImage() {
+    if (selectedImageWrapper && selectedImageWrapper.classList) {
+      selectedImageWrapper.classList.remove("selected");
+    }
+    selectedImageName = null;
+    selectedImageWrapper = null;
+  }
+
+  function selectImage(name, wrapper) {
+    if (!name || !wrapper) return;
+    if (selectedImageWrapper && selectedImageWrapper !== wrapper) {
+      selectedImageWrapper.classList.remove("selected");
+    }
+    selectedImageName = name;
+    selectedImageWrapper = wrapper;
+    wrapper.classList.add("selected");
+    if (isMobileViewport()) {
+      closeImageLibrary();
+    }
+  }
+
+  if (mobileImageToggle) {
+    mobileImageToggle.addEventListener("click", () => {
+      if (imagesSection && imagesSection.classList.contains("is-open")) {
+        closeImageLibrary();
+      } else {
+        openImageLibrary();
+      }
+    });
+  }
+
+  if (mobileModalClose) {
+    mobileModalClose.addEventListener("click", () => {
+      closeImageLibrary();
+    });
+  }
+
+  if (mobileImageBackdrop) {
+    mobileImageBackdrop.addEventListener("click", () => {
+      closeImageLibrary();
+    });
+  }
+
+  window.addEventListener("resize", () => {
+    if (!isMobileViewport()) {
+      closeImageLibrary();
+    }
+  });
+
+  document.addEventListener("keydown", (event) => {
+    if (event.key === "Escape") {
+      closeImageLibrary();
+    }
+  });
 
   function getPanelContent(panel) {
     if (!panel) return null;
@@ -310,6 +399,79 @@ window.addEventListener("DOMContentLoaded", () => {
       console.warn(`No .layout div found in template: ${layoutName}`);
     }
 
+    function removeSlotInputs(slot) {
+      container
+        .querySelectorAll(`input[name="pages[${pageIndex}][slots][${slot}]"]`)
+        .forEach((input) => input.remove());
+      container
+        .querySelectorAll(`input[name="pages[${pageIndex}][transforms][${slot}]"]`)
+        .forEach((input) => input.remove());
+    }
+
+    function placeImageInPanel(panel, slot, imageName, options = {}) {
+      if (!panel || !imageName) return false;
+      const content = getPanelContent(panel);
+      if (!content) return false;
+
+      const {
+        initialTransform = {},
+        skipLibraryUpdate = false,
+        skipSave = false,
+      } = options;
+
+      removeSlotInputs(slot);
+      clearPanel(panel);
+
+      const clone = document.createElement("img");
+      clone.src = `/uploads/${imageName}`;
+      clone.draggable = false;
+      clone.dataset.name = imageName;
+      clone.classList.add("panel-image");
+
+      const transformInput = document.createElement("input");
+      transformInput.type = "hidden";
+      transformInput.name = `pages[${pageIndex}][transforms][${slot}]`;
+      transformInput.value = JSON.stringify(initialTransform || {});
+      container.appendChild(transformInput);
+      enableImageControls(clone, transformInput, initialTransform || {});
+
+      const hidden = document.createElement("input");
+      hidden.type = "hidden";
+      hidden.name = `pages[${pageIndex}][slots][${slot}]`;
+      hidden.value = imageName;
+      container.appendChild(hidden);
+
+      content.appendChild(clone);
+
+      if (!skipLibraryUpdate) {
+        setTimeout(() => {
+          updateImages(
+            typeof initialImages !== "undefined" ? initialImages : [],
+          );
+        }, 0);
+      }
+
+      if (!skipSave) {
+        debouncedSave();
+      }
+
+      return true;
+    }
+
+    function handleSelectedImagePlacement(panel, slot) {
+      if (!selectedImageName) {
+        if (isMobileViewport()) {
+          openImageLibrary();
+        }
+        return false;
+      }
+      const placed = placeImageInPanel(panel, slot, selectedImageName);
+      if (placed) {
+        clearSelectedImage();
+      }
+      return placed;
+    }
+
     container.querySelectorAll(".panel").forEach((panel) => {
       const slot = panel.getAttribute("data-slot");
 
@@ -333,79 +495,41 @@ window.addEventListener("DOMContentLoaded", () => {
         // Remove the entire image-wrapper for the new image
         const wrapper = img.closest(".image-wrapper");
         if (wrapper) wrapper.remove();
-
-        // If panel already has an image, return it to imageList
-        const oldImg = getPanelImage(panel);
-        if (oldImg) {
-          const oldName = oldImg.dataset.name;
-          // Remove old image's hidden inputs
-          const hiddenInputs = container.querySelectorAll(
-            `input[value="${oldName}"]`,
-          );
-          hiddenInputs.forEach((input) => input.remove());
-
-          // Return image to list by refreshing the image list
-          // This ensures proper state management
-          setTimeout(() => {
-            updateImages(
-              typeof initialImages !== "undefined" ? initialImages : [],
-            );
-          }, 0);
+        if (selectedImageName === name) {
+          clearSelectedImage();
         }
 
-        clearPanel(panel);
-        const content = getPanelContent(panel);
-        if (!content) return;
-        const clone = img.cloneNode();
-        clone.draggable = false;
-        clone.classList.remove("thumb");
-        clone.classList.add("panel-image");
-        clone.removeAttribute("width");
-        clone.removeAttribute("height");
-        clone.removeAttribute("style");
-        const transformInput = document.createElement("input");
-        transformInput.type = "hidden";
-        transformInput.name = `pages[${pageIndex}][transforms][${slot}]`;
-        container.appendChild(transformInput);
-        enableImageControls(clone, transformInput);
-        content.appendChild(clone);
-        const hidden = document.createElement("input");
-        hidden.type = "hidden";
-        hidden.name = `pages[${pageIndex}][slots][${slot}]`;
-        hidden.value = name;
-        container.appendChild(hidden);
-        debouncedSave(); // Use debounced save for drag & drop
+        placeImageInPanel(panel, slot, name);
       });
 
       if (slots[slot]) {
         // For page restoration, don't try to find image in imageList since it was filtered out by PHP
         // Instead, create the image element directly
         const imageName = slots[slot];
-        const clone = document.createElement("img");
-        clone.src = `/uploads/${imageName}`;
-        clone.draggable = false;
-        clone.dataset.name = imageName;
-        clone.classList.add("panel-image");
-
-        const transformInput = document.createElement("input");
-        transformInput.type = "hidden";
-        transformInput.name = `pages[${pageIndex}][transforms][${slot}]`;
         const initial = transforms[slot] || {};
-        transformInput.value = JSON.stringify(initial);
-        container.appendChild(transformInput);
-        enableImageControls(clone, transformInput, initial);
-        const content = getPanelContent(panel);
-        if (content) {
-          clearPanel(panel);
-          content.appendChild(clone);
-        }
-
-        const hidden = document.createElement("input");
-        hidden.type = "hidden";
-        hidden.name = `pages[${pageIndex}][slots][${slot}]`;
-        hidden.value = imageName;
-        container.appendChild(hidden);
+        placeImageInPanel(panel, slot, imageName, {
+          initialTransform: initial,
+          skipLibraryUpdate: true,
+          skipSave: true,
+        });
       }
+
+      let lastTouchTime = 0;
+
+      panel.addEventListener("touchend", (event) => {
+        if (event.touches && event.touches.length > 0) return;
+        const now = Date.now();
+        if (now - lastTouchTime < 300) {
+          event.preventDefault();
+          handleSelectedImagePlacement(panel, slot);
+        }
+        lastTouchTime = now;
+      });
+
+      panel.addEventListener("dblclick", (event) => {
+        event.preventDefault();
+        handleSelectedImagePlacement(panel, slot);
+      });
     });
   }
 
@@ -728,11 +852,29 @@ window.addEventListener("DOMContentLoaded", () => {
       if (!assigned.has(name)) {
         const wrapper = document.createElement("div");
         wrapper.className = "image-wrapper";
+        wrapper.dataset.name = name;
         const img = document.createElement("img");
         img.src = `/uploads/${name}`;
         img.className = "thumb";
         img.draggable = true;
         img.dataset.name = name;
+
+        if (selectedImageName === name) {
+          wrapper.classList.add("selected");
+          selectedImageWrapper = wrapper;
+        }
+
+        img.setAttribute("role", "button");
+        img.setAttribute("tabindex", "0");
+        img.addEventListener("click", () => {
+          selectImage(name, wrapper);
+        });
+        img.addEventListener("keydown", (event) => {
+          if (event.key === "Enter" || event.key === " ") {
+            event.preventDefault();
+            selectImage(name, wrapper);
+          }
+        });
 
         // Add delete button
         const delBtn = document.createElement("button");
@@ -752,6 +894,9 @@ window.addEventListener("DOMContentLoaded", () => {
               if (!imageList.querySelector(".image-wrapper")) {
                 imageList.appendChild(createImagePlaceholder());
               }
+              if (selectedImageName === name) {
+                clearSelectedImage();
+              }
             });
         });
         wrapper.appendChild(img);
@@ -763,6 +908,13 @@ window.addEventListener("DOMContentLoaded", () => {
 
     if (appended === 0) {
       imageList.appendChild(createImagePlaceholder());
+    }
+
+    if (
+      selectedImageName &&
+      !imageList.querySelector(`.image-wrapper[data-name="${selectedImageName}"]`)
+    ) {
+      clearSelectedImage();
     }
   }
 


### PR DESCRIPTION
## Summary
- add a persistent mobile image dock and full-screen modal for the asset library
- support selecting an image, highlighting it, and placing it in a panel with a double tap or double click
- document the new touch workflow in the README and changelog

## Testing
- ./vendor/bin/phpunit *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68d5205eb4cc832a8a0232e0da050b50