### PR TITLE
Animate keyboard shortcut toggle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 ## [Unreleased]
 ### Added
 - Stream live page updates over Server-Sent Events so any open workspace reacts immediately when `state.json` is modified.
+- Support drag-and-drop uploads with visual feedback in the asset library.
+- Provide reset, save state, and load state controls that archive the SQLite database with uploaded images in a downloadable ZIP.
+- Introduce a workspace help toggle that reveals the keyboard shortcut reference with a smooth animated transition.
 
 ### Changed
 - Rebuilt the entire interface with a modern glassmorphism aesthetic, refreshed typography, and responsive layout cards to separate the asset library from the page builder.

--- a/README.md
+++ b/README.md
@@ -4,12 +4,13 @@ A modern MVC PHP application for crafting comic spreads. Upload artwork, drag it
 
 ## Features
 
-- **Curated asset library** – Upload multiple images at once and manage them with quick delete actions.
+- **Curated asset library** – Upload multiple images at once, drag-and-drop new artwork directly into the library, and manage assets with quick delete actions.
 - **Storyboard workspace** – Drag panels into dynamic templates, adjust gutter colors, and fine-tune each panel's zoom and position.
 - **Live autosave** – Progress is preserved automatically, with inline feedback to confirm every change.
 - **Real-time sync** – The browser listens to server-sent events so every open tab mirrors updates written to `state.json` instantly.
 - **One-click exports** – Generate PDFs or high-quality image sets directly from the browser.
-- **Keyboard shortcuts** – Stay in flow with quick commands for saving, creating pages, and exporting.
+- **State snapshots** – Reset the entire workspace in one click or save and restore zipped archives that bundle the SQLite state and uploaded images.
+- **Keyboard shortcuts** – Stay in flow with quick commands for saving, creating pages, and exporting, and reveal the animated cheatsheet on demand with the workspace help toggle.
 
 ## Setup
 
@@ -25,7 +26,11 @@ A modern MVC PHP application for crafting comic spreads. Upload artwork, drag it
 
 Uploaded images are stored in `public/uploads/`. Generated exports live in `public/storage/generated/`.
 
+State archives download as ZIP files that include `state.db` alongside every asset in `public/uploads/`. Restoring a snapshot replaces the database and asset library with the archive contents.
+
 ## Keyboard Shortcuts
+
+Open the workspace help menu next to **Add Page** to reveal these commands when you need a refresher.
 
 | Shortcut | Action |
 | --- | --- |

--- a/app/Controllers/StateController.php
+++ b/app/Controllers/StateController.php
@@ -1,0 +1,201 @@
+<?php
+namespace App\Controllers;
+
+use App\Models\ComicModel;
+
+class StateController
+{
+    private ComicModel $model;
+
+    public function __construct()
+    {
+        $this->model = new ComicModel();
+    }
+
+    public function reset(): void
+    {
+        header('Content-Type: application/json');
+
+        try {
+            $state = $this->model->resetState();
+            $images = $this->model->getImages();
+
+            echo json_encode([
+                'status' => 'ok',
+                'pages' => $state['pages'] ?? [],
+                'images' => $images,
+            ]);
+        } catch (\Throwable $e) {
+            http_response_code(500);
+            echo json_encode(['error' => $e->getMessage()]);
+        }
+    }
+
+    public function export(): void
+    {
+        $tempFile = tempnam(sys_get_temp_dir(), 'state_');
+        if ($tempFile === false) {
+            http_response_code(500);
+            echo 'Failed to create temporary file.';
+            return;
+        }
+
+        $archivePath = $tempFile . '.zip';
+        if (!@rename($tempFile, $archivePath)) {
+            @unlink($tempFile);
+            http_response_code(500);
+            echo 'Failed to prepare temporary archive.';
+            return;
+        }
+
+        $zip = new \ZipArchive();
+        if ($zip->open($archivePath, \ZipArchive::CREATE | \ZipArchive::OVERWRITE) !== true) {
+            http_response_code(500);
+            echo 'Unable to open archive for writing.';
+            @unlink($archivePath);
+            return;
+        }
+
+        $statePath = $this->model->getStateFilePath();
+        if (is_file($statePath)) {
+            $zip->addFile($statePath, 'state.db');
+        }
+
+        foreach ($this->model->listImageFiles() as $file) {
+            $zip->addFile($file, 'uploads/' . basename($file));
+        }
+
+        $zip->close();
+
+        header('Content-Type: application/zip');
+        header('Content-Length: ' . filesize($archivePath));
+        header(
+            'Content-Disposition: attachment; filename="comic-state-' .
+            date('Ymd-His') .
+            '.zip"'
+        );
+
+        readfile($archivePath);
+        unlink($archivePath);
+    }
+
+    public function import(): void
+    {
+        header('Content-Type: application/json');
+
+        if (empty($_FILES['state']['tmp_name'])) {
+            http_response_code(400);
+            echo json_encode(['error' => 'No archive uploaded.']);
+            return;
+        }
+
+        $tmpPath = $_FILES['state']['tmp_name'];
+        $zip = new \ZipArchive();
+        if ($zip->open($tmpPath) !== true) {
+            http_response_code(400);
+            echo json_encode(['error' => 'Unable to open uploaded archive.']);
+            return;
+        }
+
+        $extractDir = sys_get_temp_dir() . '/state_' . bin2hex(random_bytes(8));
+        if (!mkdir($extractDir, 0777, true) && !is_dir($extractDir)) {
+            $zip->close();
+            http_response_code(500);
+            echo json_encode(['error' => 'Failed to create extraction directory.']);
+            return;
+        }
+
+        try {
+            if (!$zip->extractTo($extractDir)) {
+                throw new \RuntimeException('Failed to extract archive contents.');
+            }
+        } catch (\Throwable $e) {
+            $zip->close();
+            $this->cleanupDirectory($extractDir);
+            http_response_code(400);
+            echo json_encode(['error' => $e->getMessage()]);
+            return;
+        }
+
+        $zip->close();
+
+        try {
+            $dbPath = $this->findFileByName($extractDir, 'state.db');
+            if (!$dbPath) {
+                throw new \RuntimeException('Uploaded archive does not contain state.db.');
+            }
+
+            $uploadsDir = $this->findDirectoryByName($extractDir, 'uploads');
+
+            $this->model->importStateFromDatabase($dbPath);
+            $this->model->replaceUploadsFromDirectory($uploadsDir ?: '');
+
+            $pages = $this->model->getPages();
+            $images = $this->model->getImages();
+
+            echo json_encode([
+                'status' => 'ok',
+                'pages' => $pages,
+                'images' => $images,
+            ]);
+        } catch (\Throwable $e) {
+            http_response_code(400);
+            echo json_encode(['error' => $e->getMessage()]);
+        } finally {
+            $this->cleanupDirectory($extractDir);
+        }
+    }
+
+    private function cleanupDirectory(string $path): void
+    {
+        if (!is_dir($path)) {
+            return;
+        }
+
+        $iterator = new \RecursiveIteratorIterator(
+            new \RecursiveDirectoryIterator($path, \FilesystemIterator::SKIP_DOTS),
+            \RecursiveIteratorIterator::CHILD_FIRST
+        );
+
+        foreach ($iterator as $item) {
+            if ($item->isDir()) {
+                @rmdir($item->getPathname());
+            } else {
+                @unlink($item->getPathname());
+            }
+        }
+
+        @rmdir($path);
+    }
+
+    private function findFileByName(string $baseDir, string $fileName): ?string
+    {
+        $iterator = new \RecursiveIteratorIterator(
+            new \RecursiveDirectoryIterator($baseDir, \FilesystemIterator::SKIP_DOTS)
+        );
+
+        foreach ($iterator as $file) {
+            if ($file->isFile() && strtolower($file->getFilename()) === strtolower($fileName)) {
+                return $file->getPathname();
+            }
+        }
+
+        return null;
+    }
+
+    private function findDirectoryByName(string $baseDir, string $directoryName): ?string
+    {
+        $iterator = new \RecursiveIteratorIterator(
+            new \RecursiveDirectoryIterator($baseDir, \FilesystemIterator::SKIP_DOTS),
+            \RecursiveIteratorIterator::SELF_FIRST
+        );
+
+        foreach ($iterator as $file) {
+            if ($file->isDir() && strtolower($file->getFilename()) === strtolower($directoryName)) {
+                return $file->getPathname();
+            }
+        }
+
+        return null;
+    }
+}

--- a/app/Core/Router.php
+++ b/app/Core/Router.php
@@ -15,6 +15,9 @@ class Router
             $r->addRoute('POST', '/save-pages', ['PageController', 'save']);
             $r->addRoute('GET', '/get-pages', ['PageController', 'get']);
             $r->addRoute('GET', '/pages/stream', ['PageController', 'stream']);
+            $r->addRoute('POST', '/state/reset', ['StateController', 'reset']);
+            $r->addRoute('GET', '/state/export', ['StateController', 'export']);
+            $r->addRoute('POST', '/state/import', ['StateController', 'import']);
         });
     }
 

--- a/app/Views/index.php
+++ b/app/Views/index.php
@@ -23,6 +23,10 @@
         <div class="header-actions">
             <button id="exportPdf" type="button" class="ghost">Export PDF</button>
             <button id="exportImages" type="button" class="ghost">Export Images</button>
+            <button id="resetWorkspace" type="button" class="ghost danger">Reset Workspace</button>
+            <button id="saveState" type="button" class="ghost">Save State</button>
+            <button id="loadState" type="button" class="ghost">Load State</button>
+            <input type="file" id="loadStateInput" accept="application/zip" hidden />
         </div>
     </header>
     <main class="app-main">
@@ -53,9 +57,10 @@
                 </div>
                 <div class="toolbar-actions">
                     <button id="addPage" type="button" class="primary">Add Page</button>
+                    <button id="toggleShortcuts" type="button" class="ghost" aria-expanded="false" aria-controls="shortcutList">Show Shortcuts</button>
                 </div>
             </div>
-            <ul class="shortcuts">
+            <ul id="shortcutList" class="shortcuts" aria-hidden="true">
                 <li><span>Ctrl + S</span>Quick save</li>
                 <li><span>Ctrl + N</span>New page</li>
                 <li><span>Ctrl + E</span>Export PDF</li>

--- a/public/css/style.css
+++ b/public/css/style.css
@@ -148,6 +148,18 @@ body {
     padding: 18px 20px 20px;
 }
 
+#uploadForm.drag-active {
+    border-style: dashed;
+    border-color: var(--accent);
+    background: rgba(99, 102, 241, 0.12);
+    box-shadow: 0 0 0 2px rgba(99, 102, 241, 0.18);
+}
+
+#uploadForm.drag-active input[type="file"] {
+    border-color: var(--accent);
+    color: var(--text-primary);
+}
+
 .field-label {
     font-size: 0.85rem;
     letter-spacing: 0.06em;
@@ -233,6 +245,26 @@ button.ghost:focus {
     border-color: rgba(99, 102, 241, 0.4);
     transform: translateY(-1px);
     outline: none;
+}
+
+button.ghost.active {
+    background: rgba(99, 102, 241, 0.24);
+    border-color: rgba(99, 102, 241, 0.6);
+    color: #fff;
+}
+
+button.danger {
+    background: rgba(239, 68, 68, 0.16);
+    color: #fee2e2;
+    border: 1px solid rgba(239, 68, 68, 0.4);
+}
+
+button.danger:hover,
+button.danger:focus {
+    background: rgba(239, 68, 68, 0.24);
+    border-color: rgba(239, 68, 68, 0.6);
+    color: #fff5f5;
+    transform: translateY(-1px);
 }
 
 #imageList {
@@ -321,6 +353,13 @@ button.ghost:focus {
     gap: 18px;
 }
 
+.toolbar-actions {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    flex-wrap: wrap;
+}
+
 .shortcuts {
     display: grid;
     grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
@@ -328,6 +367,20 @@ button.ghost:focus {
     padding: 0;
     margin: 0;
     gap: 12px;
+    --shortcuts-expanded-height: 0px;
+    max-height: 0;
+    opacity: 0;
+    visibility: hidden;
+    overflow: hidden;
+    transform: translateY(-6px);
+    transition: max-height var(--transition), opacity var(--transition), transform var(--transition);
+}
+
+.shortcuts.is-open {
+    max-height: var(--shortcuts-expanded-height, 520px);
+    opacity: 1;
+    visibility: visible;
+    transform: translateY(0);
 }
 
 .shortcuts li {
@@ -352,6 +405,12 @@ button.ghost:focus {
     color: var(--text-primary);
     font-weight: 600;
     font-size: 0.75rem;
+}
+
+@media (prefers-reduced-motion: reduce) {
+    .shortcuts {
+        transition: none;
+    }
 }
 
 #pages {

--- a/tests/StateManagementTest.php
+++ b/tests/StateManagementTest.php
@@ -1,0 +1,47 @@
+<?php
+require __DIR__ . '/../vendor/autoload.php';
+
+use App\Models\ComicModel;
+
+$model = new ComicModel();
+$uploadDir = $model->getUploadDirectory();
+
+if (!is_dir($uploadDir)) {
+    mkdir($uploadDir, 0777, true);
+}
+
+$dummyUpload = $uploadDir . '/__state-test__.png';
+file_put_contents($dummyUpload, 'fake');
+
+$model->resetState();
+$state = $model->getStateSnapshot();
+$remainingFiles = array_filter(glob($uploadDir . '/*') ?: [], 'is_file');
+
+if (!empty($state['images'])) {
+    fwrite(STDERR, "Expected resetState() to clear the tracked images list." . PHP_EOL);
+    exit(1);
+}
+
+if (!empty($remainingFiles)) {
+    fwrite(STDERR, "Expected resetState() to remove uploaded files from disk." . PHP_EOL);
+    exit(1);
+}
+
+$tempDir = sys_get_temp_dir() . '/state_import_' . bin2hex(random_bytes(5));
+mkdir($tempDir, 0777, true);
+$sourceImage = $tempDir . '/imported.png';
+file_put_contents($sourceImage, 'fake');
+
+$model->replaceUploadsFromDirectory($tempDir);
+$imagesAfterImport = $model->getImages();
+
+if (!in_array('imported.png', $imagesAfterImport, true)) {
+    fwrite(STDERR, "Expected replaceUploadsFromDirectory() to copy images into the upload directory." . PHP_EOL);
+    exit(1);
+}
+
+$model->resetState();
+@unlink($sourceImage);
+@rmdir($tempDir);
+
+echo "State management helpers behaved as expected." . PHP_EOL;


### PR DESCRIPTION
## Summary
- animate the workspace keyboard shortcut list with ARIA-friendly toggling logic
- add CSS transitions and reduced-motion support for the shortcuts panel reveal
- note the animated cheatsheet in the README and changelog

## Testing
- php -l app/Views/index.php
- php tests/ComicModelTemplateRenderingTest.php
- php tests/LayoutTemplateTest.php
- php tests/SessionLockTest.php
- php tests/StateManagementTest.php

------
https://chatgpt.com/codex/tasks/task_e_68d51fa41180832aa0beb68f72a0ee8a