### PR TITLE
Add page lock control to freeze layout edits

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Support drag-and-drop uploads with visual feedback in the asset library.
 - Provide reset, save state, and load state controls that archive the SQLite database with uploaded images in a downloadable ZIP.
 - Introduce a workspace help toggle that reveals the keyboard shortcut reference with a smooth animated transition.
+- Add a lock toggle next to each page so spreads can be frozen (yellow “L”) or unlocked (green “U”) to prevent accidental image edits.
 
 ### Changed
 - Rebuilt the entire interface with a modern glassmorphism aesthetic, refreshed typography, and responsive layout cards to separate the asset library from the page builder.

--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ A modern MVC PHP application for crafting comic spreads. Upload artwork, drag it
 
 - **Curated asset library** – Upload multiple images at once, drag-and-drop new artwork directly into the library, and manage assets with quick delete actions.
 - **Storyboard workspace** – Drag panels into dynamic templates, adjust gutter colors, and fine-tune each panel's zoom and position.
+- **Page locking** – Toggle a green “U”/yellow “L” control to freeze a page so placed artwork can't be moved, resized, or replaced until it’s unlocked.
 - **Live autosave** – Progress is preserved automatically, with inline feedback to confirm every change.
 - **Real-time sync** – The browser listens to server-sent events so every open tab mirrors updates written to `state.json` instantly.
 - **One-click exports** – Generate PDFs or high-quality image sets directly from the browser.

--- a/public/css/style.css
+++ b/public/css/style.css
@@ -345,6 +345,40 @@ button.danger:focus {
     outline: none;
 }
 
+.page-lock-btn {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    font-size: 1rem;
+    font-weight: 600;
+    padding: 10px 14px;
+    border-radius: var(--radius-sm);
+    background: rgba(34, 197, 94, 0.16);
+    color: #bbf7d0;
+    border: 1px solid rgba(34, 197, 94, 0.42);
+    transition: background var(--transition), border var(--transition), transform var(--transition);
+}
+
+.page-lock-btn:hover,
+.page-lock-btn:focus {
+    background: rgba(34, 197, 94, 0.28);
+    border-color: rgba(34, 197, 94, 0.58);
+    transform: translateY(-1px);
+    outline: none;
+}
+
+.page-lock-btn.is-locked {
+    background: rgba(250, 204, 21, 0.26);
+    color: #facc15;
+    border-color: rgba(234, 179, 8, 0.55);
+}
+
+.page-lock-btn.is-locked:hover,
+.page-lock-btn.is-locked:focus {
+    background: rgba(250, 204, 21, 0.36);
+    border-color: rgba(202, 138, 4, 0.75);
+}
+
 .workspace-toolbar {
     display: flex;
     flex-wrap: wrap;
@@ -445,7 +479,7 @@ button.danger:focus {
 
 .page-controls {
     display: grid;
-    grid-template-columns: 1fr 44px;
+    grid-template-columns: minmax(0, 1fr) repeat(3, 44px);
     gap: 20px;
     align-items: stretch;
     width: 100%;
@@ -499,26 +533,28 @@ button.danger:focus {
     height: 44px;
 }
 
-.page-controls .delete-page-btn {
-    width: 100%;
-    min-height: 44px;
-    font-size: 1.25rem;
-    line-height: 1;
-}
-
-/* New layout-specific styles */
 .page-controls .delete-page-btn,
-.page-controls .gutter-selector input[type="color"] {
+.page-controls .gutter-selector input[type="color"],
+.page-controls .page-lock-btn {
     width: 44px;
     height: 44px;
     padding: 0;
     aspect-ratio: 1 / 1;
 }
 
+.page-controls .delete-page-btn {
+    font-size: 1.25rem;
+    line-height: 1;
+}
+
 .page-controls .layout-selector select {
     width: 100%;
     height: 44px;
     padding: 10px 14px;
+}
+
+.page.is-locked .panel-image {
+    cursor: not-allowed !important;
 }
 
 .page select:focus,

--- a/public/js/app.js
+++ b/public/js/app.js
@@ -22,6 +22,12 @@ window.addEventListener("DOMContentLoaded", () => {
   let selectedImageName = null;
   let selectedImageWrapper = null;
 
+  function isPageLocked(node) {
+    if (!node) return false;
+    const page = node.closest(".page");
+    return page ? page.classList.contains("is-locked") : false;
+  }
+
   function isMobileViewport() {
     return window.matchMedia("(max-width: 768px)").matches;
   }
@@ -298,7 +304,8 @@ window.addEventListener("DOMContentLoaded", () => {
           };
         }
       });
-      pages.push({ layout, gutterColor, slots, transforms });
+      const locked = pageDiv.classList.contains("is-locked");
+      pages.push({ layout, gutterColor, slots, transforms, locked });
     });
     return pages;
   }
@@ -371,6 +378,10 @@ window.addEventListener("DOMContentLoaded", () => {
     let translateY = parseFloat(initial.translateY || 0);
     let rafId = null;
 
+    function updateCursor() {
+      img.style.cursor = isPageLocked(img) ? "not-allowed" : "move";
+    }
+
     function updateTransform() {
       if (rafId) return; // Prevent multiple simultaneous updates
 
@@ -387,6 +398,10 @@ window.addEventListener("DOMContentLoaded", () => {
     }
 
     img.addEventListener("wheel", (e) => {
+      if (isPageLocked(img)) {
+        e.preventDefault();
+        return;
+      }
       e.preventDefault();
       const delta = e.deltaY < 0 ? 0.1 : -0.1;
       scale = Math.min(3, Math.max(0.5, scale + delta));
@@ -397,6 +412,11 @@ window.addEventListener("DOMContentLoaded", () => {
     let dragging = false;
     let startX, startY;
     img.addEventListener("mousedown", (e) => {
+      if (isPageLocked(img)) {
+        e.preventDefault();
+        updateCursor();
+        return;
+      }
       e.preventDefault();
       dragging = true;
       startX = e.clientX - translateX;
@@ -420,6 +440,7 @@ window.addEventListener("DOMContentLoaded", () => {
     });
 
     updateTransform();
+    updateCursor();
   }
 
   function returnImagesFromPage(container) {
@@ -523,6 +544,10 @@ window.addEventListener("DOMContentLoaded", () => {
 
     function placeImageInPanel(panel, slot, imageName, options = {}) {
       if (!panel || !imageName) return false;
+      const { overrideLock = false } = options;
+      if (!overrideLock && isPageLocked(panel)) {
+        return false;
+      }
       const content = getPanelContent(panel);
       if (!content) return false;
 
@@ -555,6 +580,7 @@ window.addEventListener("DOMContentLoaded", () => {
       container.appendChild(hidden);
 
       content.appendChild(clone);
+      clone.style.cursor = isPageLocked(panel) ? "not-allowed" : "move";
 
       if (!skipLibraryUpdate) {
         setTimeout(() => {
@@ -572,6 +598,9 @@ window.addEventListener("DOMContentLoaded", () => {
     }
 
     function handleSelectedImagePlacement(panel, slot) {
+      if (isPageLocked(panel)) {
+        return false;
+      }
       if (!selectedImageName) {
         if (isMobileViewport()) {
           openImageLibrary();
@@ -589,6 +618,10 @@ window.addEventListener("DOMContentLoaded", () => {
       const slot = panel.getAttribute("data-slot");
 
       panel.addEventListener("dragover", (e) => {
+        if (isPageLocked(panel)) {
+          panel.classList.remove("drag-over");
+          return;
+        }
         e.preventDefault();
         panel.classList.add("drag-over");
       });
@@ -598,6 +631,10 @@ window.addEventListener("DOMContentLoaded", () => {
       });
 
       panel.addEventListener("drop", (e) => {
+        if (isPageLocked(panel)) {
+          panel.classList.remove("drag-over");
+          return;
+        }
         e.preventDefault();
         panel.classList.remove("drag-over");
 
@@ -624,6 +661,7 @@ window.addEventListener("DOMContentLoaded", () => {
           initialTransform: initial,
           skipLibraryUpdate: true,
           skipSave: true,
+          overrideLock: true,
         });
       }
 
@@ -631,6 +669,9 @@ window.addEventListener("DOMContentLoaded", () => {
 
       panel.addEventListener("touchend", (event) => {
         if (event.touches && event.touches.length > 0) return;
+        if (isPageLocked(panel)) {
+          return;
+        }
         const now = Date.now();
         if (now - lastTouchTime < 300) {
           event.preventDefault();
@@ -641,6 +682,9 @@ window.addEventListener("DOMContentLoaded", () => {
 
       panel.addEventListener("dblclick", (event) => {
         event.preventDefault();
+        if (isPageLocked(panel)) {
+          return;
+        }
         handleSelectedImagePlacement(panel, slot);
       });
     });
@@ -649,12 +693,19 @@ window.addEventListener("DOMContentLoaded", () => {
   function createPage(data, pagesContainer = document.getElementById("pages")) {
     const page = document.createElement("div");
     page.className = "page";
-    // Add delete button
+    // Add page controls
     const deleteBtn = document.createElement("button");
     deleteBtn.type = "button";
     deleteBtn.className = "delete-page-btn";
     deleteBtn.innerHTML = '<span aria-hidden="true">✕</span>';
     deleteBtn.setAttribute("aria-label", "Remove page");
+
+    const lockBtn = document.createElement("button");
+    lockBtn.type = "button";
+    lockBtn.className = "page-lock-btn";
+    lockBtn.textContent = "U";
+    lockBtn.setAttribute("aria-label", "Lock page");
+    lockBtn.setAttribute("aria-pressed", "false");
 
     // Layout selector
     const select = document.createElement("select");
@@ -680,20 +731,13 @@ window.addEventListener("DOMContentLoaded", () => {
     gutterGroup.className = "gutter-selector";
     gutterGroup.appendChild(gutterColor);
 
-    const controlsDiv = document.createElement("div");
-    controlsDiv.className = "page-controls";
-    controlsDiv.appendChild(layoutGroup);
-    controlsDiv.appendChild(gutterGroup);
-    
-    // Create a container for controls and delete button
     const controlsContainer = document.createElement("div");
-    controlsContainer.style.display = "flex";
-    controlsContainer.style.gap = "18px";
-    controlsContainer.style.alignItems = "flex-start";
-    
-    controlsContainer.appendChild(controlsDiv);
+    controlsContainer.className = "page-controls";
+    controlsContainer.appendChild(layoutGroup);
     controlsContainer.appendChild(deleteBtn);
-    
+    controlsContainer.appendChild(lockBtn);
+    controlsContainer.appendChild(gutterGroup);
+
     page.appendChild(controlsContainer);
 
     const container = document.createElement("div");
@@ -752,6 +796,26 @@ window.addEventListener("DOMContentLoaded", () => {
     if (!data) {
       debouncedSave(); // Use debounced save for new pages
     }
+
+    const applyLockState = (locked) => {
+      page.classList.toggle("is-locked", locked);
+      lockBtn.classList.toggle("is-locked", locked);
+      lockBtn.textContent = locked ? "L" : "U";
+      lockBtn.setAttribute("aria-pressed", String(locked));
+      lockBtn.setAttribute("aria-label", locked ? "Unlock page" : "Lock page");
+      lockBtn.title = locked ? "Page locked" : "Page unlocked";
+      page.querySelectorAll(".panel-image").forEach((img) => {
+        img.style.cursor = locked ? "not-allowed" : "move";
+      });
+    };
+
+    lockBtn.addEventListener("click", () => {
+      const shouldLock = !page.classList.contains("is-locked");
+      applyLockState(shouldLock);
+      debouncedSave();
+    });
+
+    applyLockState(Boolean(data && data.locked));
 
     // Delete page logic
     deleteBtn.addEventListener("click", () => {


### PR DESCRIPTION
## Summary
- add a per-page lock toggle that persists with the saved state and disables drag/drop interactions when engaged
- update layout interactions so locked pages ignore placement, scaling, and selection events while existing panels keep their cursor feedback
- style the new lock control alongside the gutter picker, and document the feature in the README and changelog

## Testing
- php tests/LayoutTemplateTest.php
- php tests/ComicModelTemplateRenderingTest.php
- php tests/SessionLockTest.php
- php tests/StateManagementTest.php

------
https://chatgpt.com/codex/tasks/task_e_68d53cd88c04832a82d1827ec38653ae