### PR TITLE
Ensure locked pages cancel native drops while locked

### DIFF
--- a/public/js/app.js
+++ b/public/js/app.js
@@ -623,6 +623,7 @@ window.addEventListener("DOMContentLoaded", () => {
 
       panel.addEventListener("dragover", (e) => {
         if (isPageLocked(panel)) {
+          e.preventDefault();
           panel.classList.remove("drag-over");
           return;
         }
@@ -636,6 +637,7 @@ window.addEventListener("DOMContentLoaded", () => {
 
       panel.addEventListener("drop", (e) => {
         if (isPageLocked(panel)) {
+          e.preventDefault();
           panel.classList.remove("drag-over");
           return;
         }


### PR DESCRIPTION
## Summary
- prevent the browser from handling dragover and drop events on locked panels so assets aren't opened accidentally

## Testing
- _Not run (not requested)_

------
https://chatgpt.com/codex/tasks/task_e_68d544966e04832a9ac3a1b28718559a