### PR TITLE
Add GitHub Actions workflow for building Electron release from dev branch

### DIFF
--- a/.github/workflows/build-electron-release.yml
+++ b/.github/workflows/build-electron-release.yml
@@ -1,0 +1,87 @@
+name: Build Electron Release
+
+on:
+  workflow_dispatch:
+    inputs:
+      release_version:
+        description: 'Semantic version for this release (e.g. 1.0.0 or v1.0.0)'
+        required: true
+
+jobs:
+  build:
+    runs-on: windows-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          ref: dev
+
+      - name: Prepare version metadata
+        id: version
+        shell: pwsh
+        run: |
+          $inputVersion = '${{ github.event.inputs.release_version }}'
+          if (-not $inputVersion) {
+            throw 'release_version input is required.'
+          }
+          $tag = $inputVersion
+          if (-not $tag.StartsWith('v')) {
+            $tag = 'v' + $tag
+          }
+          $semver = $inputVersion
+          if ($semver.StartsWith('v')) {
+            $semver = $semver.Substring(1)
+          }
+          "tag=$tag" | Out-File -FilePath $Env:GITHUB_OUTPUT -Encoding utf8 -Append
+          "semver=$semver" | Out-File -FilePath $Env:GITHUB_OUTPUT -Encoding utf8 -Append
+
+      - name: Use Node.js 20
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: 'npm'
+
+      - name: Configure npm version
+        run: npm pkg set version=${{ steps.version.outputs.semver }}
+
+      - name: Install Node.js dependencies
+        run: npm ci
+
+      - name: Install PHP dependencies
+        run: composer install --no-dev --optimize-autoloader
+
+      - name: Download PHP runtime
+        shell: pwsh
+        run: |
+          $phpUrl = 'https://windows.php.net/downloads/releases/php-8.2.12-nts-Win32-vs16-x64.zip'
+          $phpZip = "$Env:RUNNER_TEMP\php-runtime.zip"
+          Invoke-WebRequest -Uri $phpUrl -OutFile $phpZip
+          $extractPath = "$Env:RUNNER_TEMP\php-runtime"
+          if (Test-Path $extractPath) {
+            Remove-Item -Path $extractPath -Recurse -Force
+          }
+          Expand-Archive -Path $phpZip -DestinationPath $extractPath -Force
+          $phpSource = Get-ChildItem -Path $extractPath -Directory | Select-Object -First 1
+          if (-not $phpSource) {
+            $phpSource = Get-Item -Path $extractPath
+          }
+          New-Item -ItemType Directory -Path "resources\php" -Force | Out-Null
+          Copy-Item -Path (Join-Path $phpSource.FullName '*') -Destination "resources\php" -Recurse -Force
+
+      - name: Build Windows installer
+        run: npm run dist
+
+      - name: Upload build artifact
+        uses: actions/upload-artifact@v3
+        with:
+          name: v-comic-layout-designer-${{ steps.version.outputs.semver }}
+          path: dist/v-comic-layout-designer-Setup-${{ steps.version.outputs.semver }}.exe
+
+      - name: Create GitHub release
+        uses: softprops/action-gh-release@v1
+        with:
+          tag_name: ${{ steps.version.outputs.tag }}
+          name: V Comic Layout Designer ${{ steps.version.outputs.tag }}
+          files: dist/v-comic-layout-designer-Setup-${{ steps.version.outputs.semver }}.exe
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [Unreleased]
 ### Added
+- Introduce a **Build Electron Release** GitHub Actions workflow that packages Windows installers from the `dev` branch and publishes versioned releases on demand.
 - Stream live page updates over Server-Sent Events so any open workspace reacts immediately when the SQLite `state.db` is modified.
 - Support drag-and-drop uploads with visual feedback in the asset library.
 - Provide reset, save state, and load state controls that archive the SQLite database with uploaded images in a downloadable ZIP.

--- a/README.md
+++ b/README.md
@@ -225,6 +225,15 @@ The Node.js test runner properly handles PHP process stdout and stderr streams, 
 
 All tests exit with status code `0` on success and emit a descriptive message on failure.
 
+### Release automation
+Manual Windows builds of the Electron shell can be produced directly from GitHub using the **Build Electron Release** workflow:
+
+1. Navigate to **Actions → Build Electron Release**.
+2. Trigger **Run workflow** on the `dev` branch and supply the semantic version (for example, `1.2.0`).
+3. Wait for the workflow to finish building the installer, uploading the artifact, and publishing a draft release tagged with the provided version.
+
+The workflow installs PHP and Node.js dependencies, runs the Electron packager via `npm run dist`, bundles a PHP runtime into `resources/php`, and attaches the generated installer to the GitHub release so QA can validate it before promotion.
+
 ---
 
 ## 🧱 Frontend architecture


### PR DESCRIPTION
## Summary
- add a Build Electron Release GitHub Actions workflow that checks out the dev branch and builds the Windows installer
- document the release workflow steps in the README and changelog so contributors know how to trigger it

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d672ee813c832a948eddd7b4099ca8