### PR TITLE
Configure NSIS installer for per-machine installations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 ### Added
 - Wrap the application in an Electron shell that automatically boots an embedded PHP server for desktop use.
 - Ship npm scripts for local Electron development builds and Windows installer packaging via `electron-builder`.
+- Configure the NSIS Windows installer for per-machine setups so it defaults to `C:\\Program Files`, requests elevation, and still allows opting into a custom directory.
 - Provide a manually triggered GitHub Actions workflow that bundles a PHP runtime, builds the Electron installer, uploads it as an artifact, and publishes a release.
 
 - Stream live page updates over Server-Sent Events so any open workspace reacts immediately when the SQLite `state.db` is modified.

--- a/README.md
+++ b/README.md
@@ -156,6 +156,9 @@ npm run dist
 ```
 The build process expects a PHP runtime in `resources/php`. During CI this directory is populated automatically; for manual builds download the [official PHP non-thread-safe build for Windows](https://windows.php.net/download) and extract it into `resources/php` so that `php.exe` and its DLLs sit directly inside that folder.
 
+> [!NOTE]
+> The installer now targets per-machine installs by default, so Windows will request elevation and prefill the destination directory with `C:\Program Files`. Advanced users can still opt into a different path during setup.
+
 ### Automated desktop releases
 A workflow named **Build Electron Release** lives at `.github/workflows/build-electron.yml`. Trigger it manually from GitHub with the desired semantic version (for example `1.2.0` or `v1.2.0`) to:
 1. Install PHP and Node dependencies

--- a/package.json
+++ b/package.json
@@ -53,6 +53,10 @@
         }
       ],
       "artifactName": "v-comic-layout-designer-Setup-${version}.exe"
+    },
+    "nsis": {
+      "perMachine": true,
+      "allowToChangeInstallationDirectory": true
     }
   }
 }


### PR DESCRIPTION
## Summary
- add an NSIS configuration block to enforce per-machine installs while allowing custom install paths
- document the new installer behavior in the README and changelog

## Testing
- npm run lint
- npm run dist *(fails: wine is required on Linux build agents to sign the Windows installer)*

------
https://chatgpt.com/codex/tasks/task_e_68d6aab14930832a9c53f043c056665a