### PR TITLE
Use dynamic imports for Electron startup dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 - Add a lock toggle next to each page so spreads can be frozen (yellow “L”) or unlocked (green “U”) to prevent accidental image edits.
 
 ### Changed
+- Load the Electron main process utilities (`get-port`, `wait-on`) with dynamic `import()` calls to avoid top-level CommonJS require warnings in modern runtimes.
 - Split the monolithic `app.js` client script into focused ES modules for the image library, page management, exports, and shared state to simplify maintenance.
 - Rebuilt the entire interface with a modern glassmorphism aesthetic, refreshed typography, and responsive layout cards to separate the asset library from the page builder.
 - Widened the app shell and workspace grid to give the builder canvas more horizontal breathing room on large screens while keeping the layout responsive.

--- a/README.md
+++ b/README.md
@@ -260,6 +260,7 @@ When contributing frontend features, choose the module that matches the responsi
 | --- | --- |
 | **Uploads fail silently** | Confirm `public/uploads/` is writable by your PHP process. |
 | **Event stream never resolves** | Ensure your PHP installation supports `stream_select` and that `PageController::stream()` is reachable over HTTP/1.1. |
+| **Electron dev console shows missing CommonJS modules** | The main process now pulls `get-port` and `wait-on` via dynamic `import()` calls; upgrade to Electron 28+ or Node 18+ so async imports are supported in the runtime. |
 | **Exports look misaligned** | Clear the workspace state, then verify each layout CSS file still includes matching `.panel` and `.panel-inner` wrappers. |
 | **Importing a snapshot throws an error** | The ZIP must include both `state.db` and the `uploads/` directory. Run `php tests/ImportStateFromDatabaseTest.php` locally to sanity-check the importer. |
 

--- a/electron/main.js
+++ b/electron/main.js
@@ -2,8 +2,6 @@ const { app, BrowserWindow, dialog } = require("electron");
 const path = require("path");
 const { spawn } = require("child_process");
 const fs = require("fs");
-const getPort = require("get-port");
-const waitOn = require("wait-on");
 
 let mainWindow = null;
 let phpProcess = null;
@@ -46,6 +44,9 @@ function terminatePhpServer() {
 }
 
 async function startPhpServer() {
+  const { default: getPort } = await import("get-port");
+  const { default: waitOn } = await import("wait-on");
+
   const phpBinary = resolvePhpBinary();
 
   if (!ensurePhpBinaryExists(phpBinary)) {


### PR DESCRIPTION
## Summary
- switch the Electron main process to dynamically import get-port and wait-on where they are needed
- document the runtime requirement for the new async imports in the README and changelog

## Testing
- npm run lint
- for test in tests/*.php; do echo "Running $test"; php "$test"; done

------
https://chatgpt.com/codex/tasks/task_e_68d6aab445b0832a9ad703e6ce68d111