### PR TITLE
Fix get-port usage for Electron server range

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@
 - Removed the remaining angled panel styling and export helpers so every layout now uses straightforward rectangular frames.
 
 ### Fixed
+- Avoid `TypeError: getPort.makeRange is not a function` by switching to the supported `portNumbers()` helper when reserving the embedded PHP server port.
 - Execute layout PHP templates on the server before sending them to the browser so panels render correctly in both the editor and exports.
 - Release the PHP session lock before streaming live updates so refreshing the workspace no longer hangs behind an open EventSource connection.
 - Strip library thumbnail styling from dropped artwork so newly placed panels render at full size without waiting for a page refresh.

--- a/README.md
+++ b/README.md
@@ -264,6 +264,7 @@ When contributing frontend features, choose the module that matches the responsi
 | **Uploads fail silently** | Confirm `public/uploads/` is writable by your PHP process. |
 | **Event stream never resolves** | Ensure your PHP installation supports `stream_select` and that `PageController::stream()` is reachable over HTTP/1.1. |
 | **Electron dev console shows missing CommonJS modules** | The main process now pulls `get-port` and `wait-on` via dynamic `import()` calls; upgrade to Electron 28+ or Node 18+ so async imports are supported in the runtime. |
+| **PHP server dies with `TypeError: getPort.makeRange is not a function`** | The Electron shell now uses the `portNumbers()` helper exposed by `get-port@7`. Pull the latest code and reinstall dependencies so the range generator resolves correctly. |
 | **Exports look misaligned** | Clear the workspace state, then verify each layout CSS file still includes matching `.panel` and `.panel-inner` wrappers. |
 | **Importing a snapshot throws an error** | The ZIP must include both `state.db` and the `uploads/` directory. Run `php tests/ImportStateFromDatabaseTest.php` locally to sanity-check the importer. |
 

--- a/electron/main.js
+++ b/electron/main.js
@@ -44,7 +44,7 @@ function terminatePhpServer() {
 }
 
 async function startPhpServer() {
-  const { default: getPort } = await import("get-port");
+  const { default: getPort, portNumbers } = await import("get-port");
   const { default: waitOn } = await import("wait-on");
 
   const phpBinary = resolvePhpBinary();
@@ -61,7 +61,7 @@ async function startPhpServer() {
     return null;
   }
 
-  serverPort = await getPort({ port: getPort.makeRange(9000, 9100) });
+  serverPort = await getPort({ port: portNumbers(9000, 9100) });
   const projectRoot = app.isPackaged
     ? path.join(process.resourcesPath, "app")
     : path.join(__dirname, "..");

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
-  "name": "v-comic-layout-designer-electron",
-  "version": "0.1.0",
+  "name": "Comic Layout Designer",
+  "version": "v1.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "v-comic-layout-designer-electron",
-      "version": "0.1.0",
+      "name": "Comic Layout Designer",
+      "version": "v1.0.0",
       "license": "MIT",
       "dependencies": {
         "get-port": "^7.0.0",


### PR DESCRIPTION
## Summary
- destructure the `get-port` dynamic import to access the `portNumbers` helper
- request the PHP server port using `portNumbers(9000, 9100)` to avoid the runtime TypeError
- document the fix in the changelog and troubleshooting guide

## Testing
- npm run format
- npm run lint
- npm run build *(fails: Invalid name: "Comic Layout Designer" from existing package metadata)*

------
https://chatgpt.com/codex/tasks/task_e_68d6b44f5b48832aa7a31602f681fcbe