### PR TITLE
Fix packaged PHP binary lookup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 - Add a lock toggle next to each page so spreads can be frozen (yellow “L”) or unlocked (green “U”) to prevent accidental image edits.
 
 ### Changed
+- Point the packaged Electron runtime at `resources/php/<executable>` so bundled builds can locate the embedded PHP binary without extra directory nesting.
 - Load the Electron main process utilities (`get-port`, `wait-on`) with dynamic `import()` calls to avoid top-level CommonJS require warnings in modern runtimes.
 - Split the monolithic `app.js` client script into focused ES modules for the image library, page management, exports, and shared state to simplify maintenance.
 - Rebuilt the entire interface with a modern glassmorphism aesthetic, refreshed typography, and responsive layout cards to separate the asset library from the page builder.

--- a/README.md
+++ b/README.md
@@ -159,6 +159,8 @@ The build process expects a PHP runtime in `resources/php`. During CI this direc
 > [!NOTE]
 > The installer now targets per-machine installs by default, so Windows will request elevation and prefill the destination directory with `C:\Program Files`. Advanced users can still opt into a different path during setup.
 
+Packaged builds on every platform now resolve the embedded PHP binary from `resources/php/<platform executable>`, matching the layout emitted by `electron-builder`'s `extraResources` copy step. If the file is missing the app will prompt the user to reinstall or restore the bundled runtime.
+
 ### Automated desktop releases
 A workflow named **Build Electron Release** lives at `.github/workflows/build-electron.yml`. Trigger it manually from GitHub with the desired semantic version (for example `1.2.0` or `v1.2.0`) to:
 1. Install PHP and Node dependencies

--- a/electron/main.js
+++ b/electron/main.js
@@ -16,7 +16,7 @@ function resolvePhpBinary() {
 
   if (app.isPackaged) {
     const executable = process.platform === "win32" ? "php.exe" : "php";
-    return path.join(process.resourcesPath, "resources", "php", executable);
+    return path.join(process.resourcesPath, "php", executable);
   }
 
   return "php";

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "Comic Layout Designer",
+  "name": "comic-layout-designer",
   "version": "v1.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "Comic Layout Designer",
+      "name": "comic-layout-designer",
       "version": "v1.0.0",
       "license": "MIT",
       "dependencies": {


### PR DESCRIPTION
## Summary
- update `resolvePhpBinary` to pull the bundled runtime from `resources/php/<executable>` in packaged builds
- document the embedded PHP layout in the README and changelog
- refresh the lockfile metadata after installing dependencies for formatting and packaging

## Testing
- `npm run lint`
- `npm run build`
- `timeout 20s xvfb-run -a ./dist/linux-unpacked/comic-layout-designer --no-sandbox --enable-logging`


------
https://chatgpt.com/codex/tasks/task_e_68d6b68c8db8832ab22afcc6b7608cdd