### PR TITLE
Restore per-user Windows installer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 - Add a lock toggle next to each page so spreads can be frozen (yellow “L”) or unlocked (green “U”) to prevent accidental image edits.
 
 ### Changed
+- Revert the Windows NSIS installer to per-user mode so packages default to `%LOCALAPPDATA%\\Programs` without elevation prompts.
 - Load the Electron main process utilities (`get-port`, `wait-on`) with dynamic `import()` calls to avoid top-level CommonJS require warnings in modern runtimes.
 - Split the monolithic `app.js` client script into focused ES modules for the image library, page management, exports, and shared state to simplify maintenance.
 - Rebuilt the entire interface with a modern glassmorphism aesthetic, refreshed typography, and responsive layout cards to separate the asset library from the page builder.

--- a/README.md
+++ b/README.md
@@ -157,7 +157,7 @@ npm run dist
 The build process expects a PHP runtime in `resources/php`. During CI this directory is populated automatically; for manual builds download the [official PHP non-thread-safe build for Windows](https://windows.php.net/download) and extract it into `resources/php` so that `php.exe` and its DLLs sit directly inside that folder.
 
 > [!NOTE]
-> The installer now targets per-machine installs by default, so Windows will request elevation and prefill the destination directory with `C:\Program Files`. Advanced users can still opt into a different path during setup.
+> The installer now targets per-user installs by default, so Windows writes to `%LOCALAPPDATA%\Programs\V Comic Layout Designer` without requesting elevation. Advanced users can still opt into a different path during setup.
 
 ### Automated desktop releases
 A workflow named **Build Electron Release** lives at `.github/workflows/build-electron.yml`. Trigger it manually from GitHub with the desired semantic version (for example `1.2.0` or `v1.2.0`) to:

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "Comic Layout Designer",
+  "name": "comic-layout-designer",
   "version": "v1.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "Comic Layout Designer",
+      "name": "comic-layout-designer",
       "version": "v1.0.0",
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     },
     "nsis": {
       "oneClick": false,
-      "perMachine": true,
+      "perMachine": false,
       "allowToChangeInstallationDirectory": true
     }
   }


### PR DESCRIPTION
## Summary
- set the NSIS `perMachine` flag back to `false` so the Windows installer defaults to per-user installs under %LOCALAPPDATA%
- refresh the README and changelog to document the per-user installer behavior
- align the lockfile package name casing with package.json after reinstalling dependencies

## Testing
- npm run lint
- npm run dist *(fails: wine is required on Linux builders)*

------
https://chatgpt.com/codex/tasks/task_e_68d6b6101d7c832abf6746e219a7bab6