### PR TITLE
Ensure packaged Electron server routes through index.php

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@
 - Removed the remaining angled panel styling and export helpers so every layout now uses straightforward rectangular frames.
 
 ### Fixed
+- Serve the packaged desktop build through `public/index.php` so clean routes like `/upload` and `/pages/stream` resolve correctly when using the embedded PHP server.
 - Avoid `TypeError: getPort.makeRange is not a function` by switching to the supported `portNumbers()` helper when reserving the embedded PHP server port.
 - Execute layout PHP templates on the server before sending them to the browser so panels render correctly in both the editor and exports.
 - Release the PHP session lock before streaming live updates so refreshing the workspace no longer hangs behind an open EventSource connection.

--- a/README.md
+++ b/README.md
@@ -159,6 +159,9 @@ The build process expects a PHP runtime in `resources/php`. During CI this direc
 > [!NOTE]
 > The installer now targets per-user installs by default, so Windows writes to `%LOCALAPPDATA%\Programs\V Comic Layout Designer` without requesting elevation. Advanced users can still opt into a different path during setup.
 
+> [!IMPORTANT]
+> Packaged desktop builds now route all requests through `public/index.php`, so URLs like `/upload` and `/pages/stream` resolve just as they do in development.
+
 Packaged builds on every platform now resolve the embedded PHP binary from `resources/php/<platform executable>`, matching the layout emitted by `electron-builder`'s `extraResources` copy step. If the file is missing the app will prompt the user to reinstall or restore the bundled runtime.
 
 ### Automated desktop releases

--- a/electron/main.js
+++ b/electron/main.js
@@ -66,10 +66,11 @@ async function startPhpServer() {
     ? path.join(process.resourcesPath, "app")
     : path.join(__dirname, "..");
   const publicDir = path.join(projectRoot, "public");
+  const routerScript = path.join(publicDir, "index.php");
 
   phpProcess = spawn(
     phpBinary,
-    ["-S", `127.0.0.1:${serverPort}`, "-t", publicDir],
+    ["-S", `127.0.0.1:${serverPort}`, "-t", publicDir, routerScript],
     {
       cwd: projectRoot,
       stdio: "pipe",


### PR DESCRIPTION
## Summary
- route the embedded PHP server through `public/index.php` so packaged Electron builds can resolve clean URLs
- document the router behavior in the README and changelog for future maintainers

## Testing
- npm run format
- npm run lint
- npm run dist *(fails in container: wine is required for Windows packaging)*
- curl -I http://127.0.0.1:9080/upload
- curl -I http://127.0.0.1:9080/pages/stream

------
https://chatgpt.com/codex/tasks/task_e_68d6c3742dfc832aa67f2424911e06de