### PR TITLE
Fix packaged PHP runtime path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@
 - Removed the remaining angled panel styling and export helpers so every layout now uses straightforward rectangular frames.
 
 ### Fixed
+- Ensure packaged Electron builds copy the bundled PHP runtime directly to `resources/php` so the launcher can resolve the executable without a missing `resources/resources/php` hop.
 - Avoid `TypeError: getPort.makeRange is not a function` by switching to the supported `portNumbers()` helper when reserving the embedded PHP server port.
 - Execute layout PHP templates on the server before sending them to the browser so panels render correctly in both the editor and exports.
 - Release the PHP session lock before streaming live updates so refreshing the workspace no longer hangs behind an open EventSource connection.

--- a/README.md
+++ b/README.md
@@ -154,7 +154,7 @@ This starts the PHP development server on a random open port and automatically l
 ```bash
 npm run dist
 ```
-The build process expects a PHP runtime in `resources/php`. During CI this directory is populated automatically; for manual builds download the [official PHP non-thread-safe build for Windows](https://windows.php.net/download) and extract it into `resources/php` so that `php.exe` and its DLLs sit directly inside that folder.
+The build process expects a PHP runtime in `resources/php`. During CI this directory is populated automatically; for manual builds download the [official PHP non-thread-safe build for Windows](https://windows.php.net/download) and extract it into `resources/php` so that `php.exe` and its DLLs sit directly inside that folder. Electron Builder now copies this directory straight into `resources/php` inside the packaged app (dropping the previous redundant `resources/resources/php` nesting), so the runtime lands exactly where the launcher searches for it.
 
 > [!NOTE]
 > The installer now targets per-user installs by default, so Windows writes to `%LOCALAPPDATA%\Programs\V Comic Layout Designer` without requesting elevation. Advanced users can still opt into a different path during setup.

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "extraResources": [
       {
         "from": "resources/php",
-        "to": "resources/php"
+        "to": "php"
       }
     ],
     "win": {


### PR DESCRIPTION
## Summary
- point the electron-builder extraResources target to `php` so packaged apps can locate the embedded runtime
- document the corrected packaging layout in the README and changelog

## Testing
- npm run lint
- npm run build
- npm run dist *(fails: wine is required in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d6c5da737c832aaead272d792b8b8a