### PR TITLE
Add PHP router for Electron server

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Ship npm scripts for local Electron development builds and Windows installer packaging via `electron-builder`.
 - Configure the NSIS Windows installer for per-machine setups so it defaults to `C:\\Program Files`, requests elevation, and still allows opting into a custom directory.
 - Provide a manually triggered GitHub Actions workflow that bundles a PHP runtime, builds the Electron installer, uploads it as an artifact, and publishes a release.
+- Introduce a dedicated PHP built-in server router that preserves static asset delivery while bootstrapping the FastRoute front controller.
 
 - Stream live page updates over Server-Sent Events so any open workspace reacts immediately when the SQLite `state.db` is modified.
 - Support drag-and-drop uploads with visual feedback in the asset library.
@@ -28,7 +29,7 @@
 
 ### Fixed
 - Ensure packaged Electron builds copy the bundled PHP runtime directly to `resources/php` so the launcher can resolve the executable without a missing `resources/resources/php` hop.
-- Serve the packaged desktop build through `public/index.php` so clean routes like `/upload` and `/pages/stream` resolve correctly when using the embedded PHP server.
+- Route packaged desktop builds through `public/server-router.php` so clean endpoints like `/upload` and `/pages/stream` resolve while CSS, JavaScript, and uploads continue to stream from the PHP static handler.
 - Avoid `TypeError: getPort.makeRange is not a function` by switching to the supported `portNumbers()` helper when reserving the embedded PHP server port.
 - Execute layout PHP templates on the server before sending them to the browser so panels render correctly in both the editor and exports.
 - Release the PHP session lock before streaming live updates so refreshing the workspace no longer hangs behind an open EventSource connection.

--- a/README.md
+++ b/README.md
@@ -109,6 +109,7 @@ flowchart LR
 ├── public
 │   ├── css / js          # Styled workspace shell and vanilla JS interactions
 │   ├── index.php         # Front controller that boots the router
+│   ├── server-router.php # PHP built-in server router that preserves static asset handling
 │   └── storage           # state.db and snapshot archives live here
 ├── tests                 # Lightweight smoke tests for models, layouts, and SSE helpers
 ├── composer.json         # Autoload + dependency metadata (PHP ≥ 8.0, FastRoute)
@@ -130,7 +131,7 @@ composer install
 
 ### Serve the application
 ```bash
-php -S localhost:8000 -t public
+php -S localhost:8000 -t public public/server-router.php
 ```
 
 Then visit **http://localhost:8000** and start crafting spreads. Uploaded files land in `public/uploads/`, and exports download straight to your browser.
@@ -148,7 +149,7 @@ npm install
 composer install
 npm run electron:dev
 ```
-This starts the PHP development server on a random open port and automatically loads it inside an Electron browser window.
+This starts the PHP development server on a random open port, pointing it at the custom `server-router.php` so bundled assets are still served by PHP's static file handler, and automatically loads it inside an Electron browser window.
 
 #### Build a Windows installer locally
 ```bash
@@ -160,7 +161,7 @@ The build process expects a PHP runtime in `resources/php`. During CI this direc
 > The installer now targets per-user installs by default, so Windows writes to `%LOCALAPPDATA%\Programs\V Comic Layout Designer` without requesting elevation. Advanced users can still opt into a different path during setup.
 
 > [!IMPORTANT]
-> Packaged desktop builds now route all requests through `public/index.php`, so URLs like `/upload` and `/pages/stream` resolve just as they do in development.
+> Packaged desktop builds now route all requests through `public/server-router.php`, so URLs like `/upload` and `/pages/stream` resolve just as they do in development while static assets continue to stream from PHP's built-in server handler.
 
 Packaged builds on every platform now resolve the embedded PHP binary from `resources/php/<platform executable>`, matching the layout emitted by `electron-builder`'s `extraResources` copy step. If the file is missing the app will prompt the user to reinstall or restore the bundled runtime.
 

--- a/electron/main.js
+++ b/electron/main.js
@@ -66,7 +66,7 @@ async function startPhpServer() {
     ? path.join(process.resourcesPath, "app")
     : path.join(__dirname, "..");
   const publicDir = path.join(projectRoot, "public");
-  const routerScript = path.join(publicDir, "index.php");
+  const routerScript = path.join(publicDir, "server-router.php");
 
   phpProcess = spawn(
     phpBinary,

--- a/public/server-router.php
+++ b/public/server-router.php
@@ -1,0 +1,18 @@
+<?php
+$publicDir = realpath(__DIR__);
+$uri = parse_url($_SERVER['REQUEST_URI'] ?? '/', PHP_URL_PATH) ?? '/';
+$requestedPath = rawurldecode($uri);
+
+if ($requestedPath !== '/') {
+    $fullPath = realpath($publicDir . DIRECTORY_SEPARATOR . ltrim($requestedPath, '/'));
+
+    if (
+        $fullPath !== false &&
+        str_starts_with($fullPath, $publicDir . DIRECTORY_SEPARATOR) &&
+        is_file($fullPath)
+    ) {
+        return false;
+    }
+}
+
+require $publicDir . DIRECTORY_SEPARATOR . 'index.php';


### PR DESCRIPTION
## Summary
- add a PHP router script that lets the built-in server serve static files before bootstrapping the FastRoute front controller
- point the Electron main process at the new router and document the workflow updates
- record the routing change in the changelog

## Testing
- npm run lint
- npm run build
- php -S 127.0.0.1:8080 -t public public/server-router.php & curl -I http://127.0.0.1:8080/js/app.js && curl -I http://127.0.0.1:8080/css/style.css

------
https://chatgpt.com/codex/tasks/task_e_68d6c7f1e94c832a924545072240dd7b