### PR TITLE
Realign cinematic layout geometry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [Unreleased]
 ### Added
+- Ship a `wide-top-portrait-left-two-square-right` page template featuring a cinematic 16:9 banner, a portrait well, and stacked square story beats.
 - Introduce a **Build Electron Release** GitHub Actions workflow that packages Windows installers from the `dev` branch and publishes versioned releases on demand.
 - Stream live page updates over Server-Sent Events so any open workspace reacts immediately when the SQLite `state.db` is modified.
 - Support drag-and-drop uploads with visual feedback in the asset library.
@@ -18,6 +19,7 @@
 - Locked the layout preview container to a 1:1.545 aspect ratio that matches a single page column and removed its rounded border so spreads sit flush without white bands.
 - Streamlined the page toolbar so the layout selector, gutter picker, and removal action share a single aligned row with matching control dimensions.
 - Removed the remaining angled panel styling and export helpers so every layout now uses straightforward rectangular frames.
+- Rebuilt the `wide-top-portrait-left-two-square-right` CSS so the page geometry enforces 16:9, 9:16, and 1:1 ratios while matching the existing layout positioning system.
 
 ### Fixed
 - Execute layout PHP templates on the server before sending them to the browser so panels render correctly in both the editor and exports.

--- a/README.md
+++ b/README.md
@@ -164,6 +164,7 @@ Available templates include:
 - `three-horizontal`
 - `three-vertical`
 - `four-grid`
+- `wide-top-portrait-left-two-square-right` – Cinematic 16:9 banner, 9:16 portrait column, and perfectly square stacked beats.
 
 Add your own by creating matching `.php` and `.css` files inside `layouts/`; `App\Models\ComicModel` will auto-discover and expose them to the UI.
 

--- a/layouts/wide-top-portrait-left-two-square-right.css
+++ b/layouts/wide-top-portrait-left-two-square-right.css
@@ -1,0 +1,80 @@
+.layout.wide-top-portrait-left-two-square-right {
+    --gutter-h: 12px;         /* left & right frame */
+    --gutter-top: 36px;       /* top gutter */
+    --gutter-bottom: 60px;    /* bottom gutter */
+    --gutter-middle-v: 24px;  /* separation between top banner and bottom row */
+    --gutter-stack: 14px;     /* gap between stacked square panels */
+
+    --available-width: calc(100% - (2 * var(--gutter-h)));
+
+    /* Top panel target ratio ≈ 16:9 using the available width */
+    --top-panel-height: calc(var(--available-width) * (9 / 16));
+
+    /* Bottom composition occupies the remaining height on the page */
+    --bottom-area-top: calc(var(--gutter-top) + var(--top-panel-height) + var(--gutter-middle-v));
+    --bottom-area-height: max(
+        0px,
+        calc(100% - var(--gutter-top) - var(--gutter-bottom) - var(--gutter-middle-v) - var(--top-panel-height))
+    );
+
+    /* Squares: perfectly 1:1 using the available bottom height */
+    --square-size: max(0px, calc((var(--bottom-area-height) - var(--gutter-stack)) / 2));
+    --bottom-right-width: var(--square-size);
+
+    /* Portrait: solve for 9:16 (height / width ≈ 16/9) */
+    --portrait-ratio: 1.7777778;
+    --bottom-left-width: max(
+        0px,
+        min(
+            calc(var(--bottom-area-height) / var(--portrait-ratio)),
+            calc(var(--available-width) - var(--bottom-right-width))
+        )
+    );
+
+    /* Horizontal separation between the portrait column and squares */
+    --computed-gap: max(0px, calc(var(--available-width) - var(--bottom-left-width) - var(--bottom-right-width)));
+}
+
+/* Wide cinematic panel across the top */
+.layout.wide-top-portrait-left-two-square-right .panel1 {
+    position: absolute;
+    top: var(--gutter-top);
+    left: var(--gutter-h);
+    width: var(--available-width);
+    height: var(--top-panel-height);
+}
+
+/* Tall portrait panel on the bottom left (≈9:16) */
+.layout.wide-top-portrait-left-two-square-right .panel2 {
+    position: absolute;
+    top: var(--bottom-area-top);
+    left: var(--gutter-h);
+    width: var(--bottom-left-width);
+    height: var(--bottom-area-height);
+}
+
+/* First square on the bottom right stack (≈1:1) */
+.layout.wide-top-portrait-left-two-square-right .panel3 {
+    position: absolute;
+    top: var(--bottom-area-top);
+    left: calc(var(--gutter-h) + var(--bottom-left-width) + var(--computed-gap));
+    width: var(--bottom-right-width);
+    height: var(--square-size);
+}
+
+/* Second square on the bottom right stack (≈1:1) */
+.layout.wide-top-portrait-left-two-square-right .panel4 {
+    position: absolute;
+    top: calc(var(--bottom-area-top) + var(--square-size) + var(--gutter-stack));
+    left: calc(var(--gutter-h) + var(--bottom-left-width) + var(--computed-gap));
+    width: var(--bottom-right-width);
+    height: var(--square-size);
+}
+
+/* Keep the full composition within the page frame */
+.layout.wide-top-portrait-left-two-square-right .panel1,
+.layout.wide-top-portrait-left-two-square-right .panel2,
+.layout.wide-top-portrait-left-two-square-right .panel3,
+.layout.wide-top-portrait-left-two-square-right .panel4 {
+    border-radius: inherit;
+}

--- a/layouts/wide-top-portrait-left-two-square-right.php
+++ b/layouts/wide-top-portrait-left-two-square-right.php
@@ -1,0 +1,14 @@
+<div class="layout wide-top-portrait-left-two-square-right">
+    <div class="panel panel1" data-slot="1">
+        <div class="panel-inner"></div>
+    </div>
+    <div class="panel panel2" data-slot="2">
+        <div class="panel-inner"></div>
+    </div>
+    <div class="panel panel3" data-slot="3">
+        <div class="panel-inner"></div>
+    </div>
+    <div class="panel panel4" data-slot="4">
+        <div class="panel-inner"></div>
+    </div>
+</div>

--- a/tests/LayoutStylesAvailabilityTest.php
+++ b/tests/LayoutStylesAvailabilityTest.php
@@ -1,0 +1,32 @@
+<?php
+
+require __DIR__ . '/../vendor/autoload.php';
+
+use App\Models\ComicModel;
+
+$model = new ComicModel();
+$layouts = $model->getLayouts();
+$styles = $model->getLayoutStyles();
+
+$missingCss = [];
+
+foreach ($layouts as $name => $_file) {
+    $css = $styles[$name] ?? '';
+    if (trim($css) === '') {
+        $missingCss[] = $name;
+    }
+}
+
+if ($missingCss) {
+    fwrite(
+        STDERR,
+        sprintf(
+            "Layouts missing CSS definitions: %s%s",
+            implode(', ', $missingCss),
+            PHP_EOL
+        )
+    );
+    exit(1);
+}
+
+echo "All layouts expose non-empty CSS definitions." . PHP_EOL;


### PR DESCRIPTION
## Summary
- rework the wide-top-portrait-left-two-square-right CSS to derive panel geometry from the existing layout frame so the banner, portrait, and squares hold their target ratios
- clamp the portrait column width and computed gutter to prevent overflow while matching the established absolute-position layout system
- update the layout catalog entry and changelog to reflect the corrected geometry

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d77d4b6f68832a914c811d0e763f43