### PR TITLE
Align export rendering to canonical layout dimensions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,9 @@
 # Changelog
 
 ## [Unreleased]
+
 ### Added
+
 - Ship a `wide-top-portrait-left-two-square-right` page template featuring a cinematic 16:9 banner, a portrait well, and stacked square story beats.
 - Introduce a **Build Electron Release** GitHub Actions workflow that packages Windows installers from the `dev` branch and publishes versioned releases on demand.
 - Stream live page updates over Server-Sent Events so any open workspace reacts immediately when the SQLite `state.db` is modified.
@@ -11,6 +13,7 @@
 - Add a lock toggle next to each page so spreads can be frozen (yellow “L”) or unlocked (green “U”) to prevent accidental image edits.
 
 ### Changed
+
 - Split the monolithic `app.js` client script into focused ES modules for the image library, page management, exports, and shared state to simplify maintenance.
 - Rebuilt the entire interface with a modern glassmorphism aesthetic, refreshed typography, and responsive layout cards to separate the asset library from the page builder.
 - Widened the app shell and workspace grid to give the builder canvas more horizontal breathing room on large screens while keeping the layout responsive.
@@ -22,8 +25,10 @@
 - Rebuilt the `wide-top-portrait-left-two-square-right` CSS so the page geometry enforces 16:9, 9:16, and 1:1 ratios while matching the existing layout positioning system.
 - Tuned the `wide-top-portrait-left-two-square-right` layout with clamped banner heights, a named column gutter, and responsive portrait/square sizing so it better adapts to the available page dimensions.
 - Normalize panel transforms against their parent dimensions so dragging results persist across responsive breakpoints and exports match the current layout geometry.
+- Capture exports at a canonical 900 × 1391 layout resolution and scale panel math accordingly so PDF and PNG output stays consistent regardless of the editor viewport size.
 
 ### Fixed
+
 - Execute layout PHP templates on the server before sending them to the browser so panels render correctly in both the editor and exports.
 - Release the PHP session lock before streaming live updates so refreshing the workspace no longer hangs behind an open EventSource connection.
 - Strip library thumbnail styling from dropped artwork so newly placed panels render at full size without waiting for a page refresh.
@@ -36,5 +41,6 @@
 - Treat `public/storage/state.db` as the single source of truth when rehydrating pages, removing the fallback to embedded data bundled in the HTML.
 
 ### Documentation
+
 - Replace the README with an in-depth, highly visual guide covering architecture, workflows, testing commands, and troubleshooting tips.
 - Add workspace screenshots and clarify README sections to keep the documentation accurate and actionable.

--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ flowchart LR
 | **Storyboard workspace** | Dynamic layout selector, gutter color picker, page locking (green **U**/**L** toggle), autosave banner, keyboard shortcut helper. Stored transforms are normalized to panel percentages so resizing the canvas never drifts artwork placements. |
 | **Real-time sync** | Browser EventSource streams push notifications whenever the SQLite `state.db` changes on disk, so multiple sessions stay mirrored. |
 | **State management** | Reset the world in one click, or save/load ZIP archives (`state.db` + uploads) to branch, share, or roll back progress. |
-| **Exports** | Generate high-resolution PDFs or per-page PNGs. Export dimensions respect the live panel transforms, reapplying normalized translations before drawing to preserve the 1:1.545 aspect ratio. |
+| **Exports** | Generate high-resolution PDFs or per-page PNGs. Exports are rendered at a canonical 900×1391 layout resolution so panel math stays consistent across viewports while preserving the 1:1.545 aspect ratio. |
 | **Mobile experience** | A docked **Images** pill reveals the full-screen library, double-tap panels to place art without precision dragging. |
 
 ---

--- a/public/js/pages.js
+++ b/public/js/pages.js
@@ -14,6 +14,11 @@ export const PDF_PAGE_HEIGHT = 612;
 export const PDF_COLUMN_WIDTH = PDF_PAGE_WIDTH / 2;
 export const DEFAULT_GUTTER_COLOR = "#cccccc";
 export const EXPORT_SCALE = 2;
+export const CANONICAL_LAYOUT_WIDTH = 900;
+export const CANONICAL_LAYOUT_ASPECT_RATIO = 1.545;
+export const CANONICAL_LAYOUT_HEIGHT = Math.round(
+  CANONICAL_LAYOUT_WIDTH * CANONICAL_LAYOUT_ASPECT_RATIO,
+);
 
 const dom = {
   pages: null,
@@ -78,11 +83,13 @@ function calculatePercentage(pixelValue, dimension, useFiniteCheck = false) {
   if (!dimension) {
     return 0;
   }
-  
-  const safePixelValue = useFiniteCheck 
-    ? (Number.isFinite(pixelValue) ? pixelValue : 0)
+
+  const safePixelValue = useFiniteCheck
+    ? Number.isFinite(pixelValue)
+      ? pixelValue
+      : 0
     : pixelValue;
-  
+
   return (safePixelValue / dimension) * 100;
 }
 
@@ -196,7 +203,10 @@ function enableImageControls(img, hiddenInput, initial = {}) {
     img.style.cursor = isPageLocked(img) ? "not-allowed" : "move";
   }
 
-  const applyTransform = ({ fromNormalizedX = false, fromNormalizedY = false } = {}) => {
+  const applyTransform = ({
+    fromNormalizedX = false,
+    fromNormalizedY = false,
+  } = {}) => {
     const panel = img.closest(".panel");
     const { width, height } = getPanelContentDimensions(panel);
     const baseWidth = width || img.clientWidth || img.naturalWidth || 1;
@@ -225,11 +235,19 @@ function enableImageControls(img, hiddenInput, initial = {}) {
     img.dataset.translateYPct = String(translateYPct);
 
     if (hiddenInput) {
-      hiddenInput.value = JSON.stringify({ scale, translateXPct, translateYPct });
+      hiddenInput.value = JSON.stringify({
+        scale,
+        translateXPct,
+        translateYPct,
+      });
     }
   };
 
-  const updateTransform = ({ fromNormalizedX = false, fromNormalizedY = false, immediate = false } = {}) => {
+  const updateTransform = ({
+    fromNormalizedX = false,
+    fromNormalizedY = false,
+    immediate = false,
+  } = {}) => {
     if (fromNormalizedX) {
       deriveXFromNormalized = true;
     }
@@ -320,7 +338,10 @@ function enableImageControls(img, hiddenInput, initial = {}) {
     });
   });
 
-  updateTransform({ fromNormalizedX: hasNormalizedX, fromNormalizedY: hasNormalizedY });
+  updateTransform({
+    fromNormalizedX: hasNormalizedX,
+    fromNormalizedY: hasNormalizedY,
+  });
   updateCursor();
 }
 
@@ -365,7 +386,7 @@ function placeImageInPanel({
 
   content.appendChild(clone);
   clone.style.cursor = isPageLocked(panel) ? "not-allowed" : "move";
-  
+
   // Enable image controls after appending to DOM so getPanelContentDimensions can measure actual dimensions
   enableImageControls(clone, transformInput, initialTransform || {});
 
@@ -408,7 +429,9 @@ function handleSelectedImagePlacement(panel, slot, container, pageIndex) {
 }
 
 function returnImagesFromPage(container) {
-  container.querySelectorAll('input[type="hidden"]').forEach((input) => input.remove());
+  container
+    .querySelectorAll('input[type="hidden"]')
+    .forEach((input) => input.remove());
   container.querySelectorAll(".panel").forEach((panel) => {
     clearPanel(panel);
   });
@@ -475,7 +498,9 @@ function renderLayout(
 
       const name = e.dataTransfer.getData("text/plain");
       const imageList = document.getElementById("imageList");
-      const img = imageList ? imageList.querySelector(`img[data-name="${name}"]`) : null;
+      const img = imageList
+        ? imageList.querySelector(`img[data-name="${name}"]`)
+        : null;
       if (!img) return;
 
       const wrapper = img.closest(".image-wrapper");
@@ -534,10 +559,7 @@ function renderLayout(
   });
 }
 
-export function createPage(
-  data,
-  pagesContainer = getPagesContainer(),
-) {
+export function createPage(data, pagesContainer = getPagesContainer()) {
   const page = document.createElement("div");
   page.className = "page";
 
@@ -564,7 +586,8 @@ export function createPage(
 
   const gutterColor = document.createElement("input");
   gutterColor.type = "color";
-  gutterColor.value = data && data.gutterColor ? data.gutterColor : DEFAULT_GUTTER_COLOR;
+  gutterColor.value =
+    data && data.gutterColor ? data.gutterColor : DEFAULT_GUTTER_COLOR;
   gutterColor.title = "Gutter Color";
   gutterColor.className = "gutter-color-picker";
 
@@ -669,7 +692,9 @@ export function capturePagesFromDom() {
   document.querySelectorAll("#pages > .page").forEach((pageDiv) => {
     const layout = pageDiv.querySelector("select").value;
     const gutterColorInput = pageDiv.querySelector('input[type="color"]');
-    const gutterColor = gutterColorInput ? gutterColorInput.value : DEFAULT_GUTTER_COLOR;
+    const gutterColor = gutterColorInput
+      ? gutterColorInput.value
+      : DEFAULT_GUTTER_COLOR;
     const slots = {};
     const transforms = {};
     pageDiv.querySelectorAll(".panel").forEach((panel) => {
@@ -680,8 +705,12 @@ export function capturePagesFromDom() {
         const scaleValue = parseFloat(img.dataset.scale);
         const rawTranslateXPct = parseFloat(img.dataset.translateXPct);
         const rawTranslateYPct = parseFloat(img.dataset.translateYPct);
-        let translateXPct = Number.isFinite(rawTranslateXPct) ? rawTranslateXPct : null;
-        let translateYPct = Number.isFinite(rawTranslateYPct) ? rawTranslateYPct : null;
+        let translateXPct = Number.isFinite(rawTranslateXPct)
+          ? rawTranslateXPct
+          : null;
+        let translateYPct = Number.isFinite(rawTranslateYPct)
+          ? rawTranslateYPct
+          : null;
 
         if (translateXPct === null || translateYPct === null) {
           const { width, height } = getPanelContentDimensions(panel);
@@ -819,7 +848,9 @@ function processIncomingPages(incomingPages) {
 
 export function subscribeToStateStream() {
   if (!window.EventSource) {
-    console.warn("EventSource is not supported in this browser; live sync disabled.");
+    console.warn(
+      "EventSource is not supported in this browser; live sync disabled.",
+    );
     return;
   }
 
@@ -903,7 +934,9 @@ function setupResetButton() {
   if (!resetButton) return;
 
   resetButton.addEventListener("click", () => {
-    const confirmed = window.confirm("Resetting will remove all images and pages. Continue?");
+    const confirmed = window.confirm(
+      "Resetting will remove all images and pages. Continue?",
+    );
     if (!confirmed) {
       return;
     }
@@ -947,7 +980,9 @@ function setupStateImportExport() {
       fetch("/state/export")
         .then((response) => {
           if (!response.ok) {
-            throw new Error(`Failed to export state (status ${response.status})`);
+            throw new Error(
+              `Failed to export state (status ${response.status})`,
+            );
           }
 
           const disposition = response.headers.get("Content-Disposition");
@@ -1001,7 +1036,8 @@ function setupStateImportExport() {
             .catch(() => ({ error: "State import failed" }))
             .then((data) => {
               if (!response.ok || (data && data.error)) {
-                const message = data && data.error ? data.error : "State import failed";
+                const message =
+                  data && data.error ? data.error : "State import failed";
                 throw new Error(message);
               }
 
@@ -1030,13 +1066,18 @@ function setupShortcutToggle() {
 
   const setExpandedHeight = () => {
     const currentHeight = shortcutList.scrollHeight;
-    shortcutList.style.setProperty("--shortcuts-expanded-height", `${currentHeight}px`);
+    shortcutList.style.setProperty(
+      "--shortcuts-expanded-height",
+      `${currentHeight}px`,
+    );
   };
 
   const updateToggleState = (isOpen) => {
     toggleShortcutsButton.setAttribute("aria-expanded", String(isOpen));
     toggleShortcutsButton.classList.toggle("active", isOpen);
-    toggleShortcutsButton.textContent = isOpen ? "Hide Shortcuts" : "Show Shortcuts";
+    toggleShortcutsButton.textContent = isOpen
+      ? "Hide Shortcuts"
+      : "Show Shortcuts";
     shortcutList.setAttribute("aria-hidden", String(!isOpen));
   };
 
@@ -1086,24 +1127,86 @@ export function parseRadiusValue(value) {
   return Number.isNaN(parsed) ? 0 : parsed;
 }
 
+function parseCornerRadius(value) {
+  if (typeof value === "number") {
+    const numeric = Number.isFinite(value) ? value : 0;
+    return { x: numeric, y: numeric };
+  }
+
+  if (!value) {
+    return { x: 0, y: 0 };
+  }
+
+  const sanitized = String(value).replace(/\//g, " ");
+  const parts = sanitized
+    .trim()
+    .split(/\s+/)
+    .map((part) => parseFloat(part))
+    .filter((part) => Number.isFinite(part));
+
+  if (parts.length === 0) {
+    return { x: 0, y: 0 };
+  }
+
+  const [x, y] = parts;
+  const xRadius = Number.isFinite(x) ? x : 0;
+  const yRadius = Number.isFinite(y) ? y : xRadius;
+
+  return { x: xRadius, y: yRadius };
+}
+
+function scaleCornerRadius(value, scaleX, scaleY) {
+  const { x, y } = parseCornerRadius(value);
+  return {
+    x: x * scaleX,
+    y: y * scaleY,
+  };
+}
+
 export function buildRoundedRectPath(ctx, x, y, width, height, radii) {
-  if (!radii || radii.every((r) => r === 0)) {
+  if (!radii || radii.length === 0) {
     ctx.beginPath();
     ctx.rect(x, y, width, height);
     return;
   }
 
-  const [tl, tr, br, bl] = radii;
+  const normalizedRadii = radii.map((radius) => {
+    if (!radius) {
+      return { x: 0, y: 0 };
+    }
+
+    if (typeof radius === "number") {
+      return { x: radius, y: radius };
+    }
+
+    const xRadius = Number.isFinite(radius.x) ? radius.x : 0;
+    const yRadius = Number.isFinite(radius.y) ? radius.y : 0;
+
+    return { x: xRadius, y: yRadius };
+  });
+
+  if (normalizedRadii.every((radius) => radius.x === 0 && radius.y === 0)) {
+    ctx.beginPath();
+    ctx.rect(x, y, width, height);
+    return;
+  }
+
+  const [
+    tl = { x: 0, y: 0 },
+    tr = { x: 0, y: 0 },
+    br = { x: 0, y: 0 },
+    bl = { x: 0, y: 0 },
+  ] = normalizedRadii;
   ctx.beginPath();
-  ctx.moveTo(x + tl, y);
-  ctx.lineTo(x + width - tr, y);
-  ctx.quadraticCurveTo(x + width, y, x + width, y + tr);
-  ctx.lineTo(x + width, y + height - br);
-  ctx.quadraticCurveTo(x + width, y + height, x + width - br, y + height);
-  ctx.lineTo(x + bl, y + height);
-  ctx.quadraticCurveTo(x, y + height, x, y + height - bl);
-  ctx.lineTo(x, y + tl);
-  ctx.quadraticCurveTo(x, y, x + tl, y);
+  ctx.moveTo(x + tl.x, y);
+  ctx.lineTo(x + width - tr.x, y);
+  ctx.quadraticCurveTo(x + width, y, x + width, y + tr.y);
+  ctx.lineTo(x + width, y + height - br.y);
+  ctx.quadraticCurveTo(x + width, y + height, x + width - br.x, y + height);
+  ctx.lineTo(x + bl.x, y + height);
+  ctx.quadraticCurveTo(x, y + height, x, y + height - bl.y);
+  ctx.lineTo(x, y + tl.y);
+  ctx.quadraticCurveTo(x, y, x + tl.x, y);
   ctx.closePath();
 }
 
@@ -1162,8 +1265,13 @@ export async function renderLayoutToCanvas(layout, scale = EXPORT_SCALE) {
   }
 
   const canvas = document.createElement("canvas");
-  canvas.width = Math.round(layoutRect.width * scale);
-  canvas.height = Math.round(layoutRect.height * scale);
+  const baseScaleX = CANONICAL_LAYOUT_WIDTH / layoutRect.width;
+  const baseScaleY = CANONICAL_LAYOUT_HEIGHT / layoutRect.height;
+  const scaleX = baseScaleX * scale;
+  const scaleY = baseScaleY * scale;
+
+  canvas.width = Math.round(CANONICAL_LAYOUT_WIDTH * scale);
+  canvas.height = Math.round(CANONICAL_LAYOUT_HEIGHT * scale);
 
   const ctx = canvas.getContext("2d");
   if (!ctx) {
@@ -1175,7 +1283,11 @@ export async function renderLayoutToCanvas(layout, scale = EXPORT_SCALE) {
 
   const computedLayoutStyle = window.getComputedStyle(layout);
   let gutterColor = computedLayoutStyle.backgroundColor;
-  if (!gutterColor || gutterColor === "transparent" || gutterColor === "rgba(0, 0, 0, 0)") {
+  if (
+    !gutterColor ||
+    gutterColor === "transparent" ||
+    gutterColor === "rgba(0, 0, 0, 0)"
+  ) {
     gutterColor = DEFAULT_GUTTER_COLOR;
   }
 
@@ -1191,23 +1303,27 @@ export async function renderLayoutToCanvas(layout, scale = EXPORT_SCALE) {
       return;
     }
 
-    const offsetX = (panelRect.left - layoutRect.left) * scale;
-    const offsetY = (panelRect.top - layoutRect.top) * scale;
-    const panelWidth = panelRect.width * scale;
-    const panelHeight = panelRect.height * scale;
+    const offsetX = (panelRect.left - layoutRect.left) * scaleX;
+    const offsetY = (panelRect.top - layoutRect.top) * scaleY;
+    const panelWidth = panelRect.width * scaleX;
+    const panelHeight = panelRect.height * scaleY;
 
     const panelStyle = window.getComputedStyle(panel);
     const radii = [
-      parseRadiusValue(panelStyle.borderTopLeftRadius) * scale,
-      parseRadiusValue(panelStyle.borderTopRightRadius) * scale,
-      parseRadiusValue(panelStyle.borderBottomRightRadius) * scale,
-      parseRadiusValue(panelStyle.borderBottomLeftRadius) * scale,
+      scaleCornerRadius(panelStyle.borderTopLeftRadius, scaleX, scaleY),
+      scaleCornerRadius(panelStyle.borderTopRightRadius, scaleX, scaleY),
+      scaleCornerRadius(panelStyle.borderBottomRightRadius, scaleX, scaleY),
+      scaleCornerRadius(panelStyle.borderBottomLeftRadius, scaleX, scaleY),
     ];
 
     const inner = panel.querySelector(".panel-inner");
     const innerStyle = inner ? window.getComputedStyle(inner) : null;
     let panelBackground = innerStyle ? innerStyle.backgroundColor : "#ffffff";
-    if (!panelBackground || panelBackground === "transparent" || panelBackground === "rgba(0, 0, 0, 0)") {
+    if (
+      !panelBackground ||
+      panelBackground === "transparent" ||
+      panelBackground === "rgba(0, 0, 0, 0)"
+    ) {
       panelBackground = "#ffffff";
     }
 
@@ -1220,10 +1336,10 @@ export async function renderLayoutToCanvas(layout, scale = EXPORT_SCALE) {
     const img = panel.querySelector("img");
     if (img && img.naturalWidth && img.naturalHeight) {
       const imgRect = img.getBoundingClientRect();
-      const imgX = (imgRect.left - layoutRect.left) * scale;
-      const imgY = (imgRect.top - layoutRect.top) * scale;
-      const imgWidth = imgRect.width * scale;
-      const imgHeight = imgRect.height * scale;
+      const imgX = (imgRect.left - layoutRect.left) * scaleX;
+      const imgY = (imgRect.top - layoutRect.top) * scaleY;
+      const imgWidth = imgRect.width * scaleX;
+      const imgHeight = imgRect.height * scaleY;
 
       if (imgWidth > 0 && imgHeight > 0) {
         ctx.drawImage(img, imgX, imgY, imgWidth, imgHeight);


### PR DESCRIPTION
## Summary
- add canonical layout constants so exports always render against a 900×1391 canvas
- scale panel drawing, border radii, and images using canonical ratios for consistent PDF/PNG output
- document the new export resolution in the README and changelog

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d9417c04a0832a8880e333903558f4